### PR TITLE
implemented on/off endpoints

### DIFF
--- a/app/eventserver.cpp
+++ b/app/eventserver.cpp
@@ -90,15 +90,15 @@ void EventServer::onClientComplete(TcpClient& client, bool succesfull)
 void EventServer::publishCurrentState(const ChannelOutput& raw, const HSVCT* pHsv)
 {
 	//debug_i("EventServer::publishCurrentState\n");
-	if(raw == _lastRaw)
+	if((raw == _lastRaw) && (pHsv == _lastpHsv)) // No change
 		return;
-
 	unsigned long currentTime = millis();
 	if(currentTime - _lastEventTime < _minEventInterval) {
 		debug_i("eventserver, droppinging currentState event");
 		return; // Silently discard this event
 	}
 	_lastRaw = raw;
+	_lastpHsv = pHsv;
 	_lastEventTime = currentTime;
 
 	JsonRpcMessage msg(F("color_event"));

--- a/app/jsonprocessor.cpp
+++ b/app/jsonprocessor.cpp
@@ -1,3 +1,4 @@
+
 #include <RGBWWCtrl.h>
 
 #define MIN_HEAP_FREE 8192
@@ -700,4 +701,46 @@ void JsonProcessor::addChannelStatesToCmd(JsonObject root, const RGBWWLed::Chann
 		break;
 	}
 	}
+}
+bool JsonProcessor::onSetOn(JsonObject root, String& msg, bool relay) {
+	RequestParameters params;
+	parseRequestParams(root, params);
+
+	app.rgbwwctrl.setOn(
+		params.channels,
+		params.direction,
+		params.ramp,
+		params.queue,
+		params.requeue,
+		params.name
+	);
+	// Optionally relay or set msg
+	return true;
+}
+
+bool JsonProcessor::onSetOff(JsonObject root, String& msg, bool relay) {
+	RequestParameters params;
+	parseRequestParams(root, params);
+
+	// If no color specified and mode is HSV, use current HSV but set v=0
+	bool hasColor = params.mode == RequestParameters::Mode::Hsv &&
+		(params.hsv.h.hasValue() || params.hsv.s.hasValue() || params.hsv.v.hasValue() || params.hsv.ct.hasValue());
+
+	if (!hasColor && app.rgbwwctrl.getMode() == RGBWWLed::ColorMode::Hsv) {
+		HSVCT current = app.rgbwwctrl.getCurrentColor();
+		params.hsv = current;
+		params.mode = RequestParameters::Mode::Hsv;
+		params.hsv.v = 0;
+	}
+
+	app.rgbwwctrl.setOff(
+		params.channels,
+		params.direction,
+		params.ramp,
+		params.queue,
+		params.requeue,
+		params.name
+	);
+	// Optionally relay or set msg
+	return true;
 }

--- a/app/ledctrl.cpp
+++ b/app/ledctrl.cpp
@@ -1,3 +1,4 @@
+
 /**
  * @file
  * @author  Patrick Jahns http://github.com/patrickjahns
@@ -558,4 +559,82 @@ void APPLedCtrl::toggle()
 		}
 	}
 	}
+}
+
+
+// SetOn/SetOff implementation (refactored to use plain arguments)
+void APPLedCtrl::setOn(const RGBWWLed::ChannelList& channels, int direction, const RampTimeOrSpeed& ramp, QueuePolicy queue, bool requeue, const String& name)
+{
+	switch(_mode) {
+	case ColorMode::Hsv: {
+		HSVCT current = getCurrentColor();
+		HSVCT target = current;
+		// If v==0, restore last nonzero HSV (toggle logic)
+		if (current.v == 0) {
+			target = _lastHsvct;
+			if (target.v == 0) target.v = 100; // fallback if last was off
+		}
+		// For HSV mode, direction/ramp/queue/requeue/name are used, but channels are ignored
+		fadeHSV(current, target, ramp, direction, queue, requeue, name);
+		break;
+	}
+	case ColorMode::Raw: {
+		ChannelOutput current = getCurrentOutput();
+		ChannelOutput target = current;
+		// If channels specified, only set those to last or 255, else all
+		if (!channels.isEmpty()) {
+			for (auto ch : channels) {
+				switch (ch) {
+					case CtrlChannel::Red: target.r = 255; break;
+					case CtrlChannel::Green: target.g = 255; break;
+					case CtrlChannel::Blue: target.b = 255; break;
+					case CtrlChannel::WarmWhite: target.ww = 255; break;
+					case CtrlChannel::ColdWhite: target.cw = 255; break;
+					default: break;
+				}
+			}
+		} else {
+			target.r = target.g = target.b = target.cw = target.ww = 255;
+		}
+		fadeRAW(current, target, ramp, queue, requeue, name);
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+void APPLedCtrl::setOff(const RGBWWLed::ChannelList& channels, int direction, const RampTimeOrSpeed& ramp, QueuePolicy queue, bool requeue, const String& name)
+{
+    switch(_mode) {
+    case ColorMode::Hsv: {
+        HSVCT current = getCurrentColor();
+        HSVCT target = current;
+        target.v = 0;
+        fadeHSV(current, target, ramp, direction, queue, requeue, name);
+        break;
+    }
+    case ColorMode::Raw: {
+        ChannelOutput current = getCurrentOutput();
+        ChannelOutput target = current;
+        if (!channels.isEmpty()) {
+            for (auto ch : channels) {
+                switch (ch) {
+                    case CtrlChannel::Red: target.r = 0; break;
+                    case CtrlChannel::Green: target.g = 0; break;
+                    case CtrlChannel::Blue: target.b = 0; break;
+                    case CtrlChannel::WarmWhite: target.ww = 0; break;
+                    case CtrlChannel::ColdWhite: target.cw = 0; break;
+                    default: break;
+                }
+            }
+        } else {
+            target.r = target.g = target.b = target.cw = target.ww = 0;
+        }
+        fadeRAW(current, target, ramp, queue, requeue, name);
+        break;
+    }
+    default:
+        break;
+    }
 }

--- a/app/webserver.cpp
+++ b/app/webserver.cpp
@@ -1,3 +1,5 @@
+#include <ArduinoJson.h>
+
 /**
  * @file
  * @author  Patrick Jahns http://github.com/patrickjahns
@@ -65,13 +67,9 @@ void ApplicationWebserver::init()
 	paths.set(F("/hosts"), HttpPathDelegate(&ApplicationWebserver::onHosts, this));
 	paths.set(F("/data"), HttpPathDelegate(&ApplicationWebserver::onData, this));
 
-	// redirectors for initial configuration
-	paths.set(F("/canonical.html"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); 
-	paths.set(F("/generate_204"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); //android
-	paths.set(F("/static/hotspot.txt"), HttpPathDelegate(&ApplicationWebserver::onIndex, this));
-	paths.set(F("/connecttest.txt"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); //Windows
-	paths.set(F("/hotspot-detect.html"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); //iOS/macOS
-	paths.set(F("/nmcheck.gnome.org"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); //Linux (NetworkManager)
+	// basic settings
+	paths.set(F("/on"), HttpPathDelegate(&ApplicationWebserver::onSetOn, this));
+	paths.set(F("/off"), HttpPathDelegate(&ApplicationWebserver::onSetOff, this));
 
 	// animation controls
 	paths.set(F("/stop"), HttpPathDelegate(&ApplicationWebserver::onStop, this));
@@ -80,6 +78,14 @@ void ApplicationWebserver::init()
 	paths.set(F("/continue"), HttpPathDelegate(&ApplicationWebserver::onContinue, this));
 	paths.set(F("/blink"), HttpPathDelegate(&ApplicationWebserver::onBlink, this));
 	paths.set(F("/toggle"), HttpPathDelegate(&ApplicationWebserver::onToggle, this));
+
+	// redirectors for initial configuration
+	paths.set(F("/canonical.html"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); 
+	paths.set(F("/generate_204"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); //android
+	paths.set(F("/static/hotspot.txt"), HttpPathDelegate(&ApplicationWebserver::onIndex, this));
+	paths.set(F("/connecttest.txt"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); //Windows
+	paths.set(F("/hotspot-detect.html"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); //iOS/macOS
+	paths.set(F("/nmcheck.gnome.org"), HttpPathDelegate(&ApplicationWebserver::onIndex, this)); //Linux (NetworkManager)
 
 	// websocket api
 	wsResource = new WebsocketResource();
@@ -1296,6 +1302,52 @@ void ApplicationWebserver::onData(HttpRequest& request, HttpResponse& response){
 	}
 
 	return;
+}
+void ApplicationWebserver::onSetOn(HttpRequest &request, HttpResponse &response) {
+	if(request.method == HTTP_OPTIONS) {
+		// probably a CORS request
+		setCorsHeaders(response);
+		sendApiCode(response, API_CODES::API_SUCCESS, "");
+		debug_i("HTTP_OPTIONS Request, sent API_SUCCESS");
+		return;
+	}
+
+	String body = request.getBody();
+	StaticJsonDocument<512> doc;
+	DeserializationError err = deserializeJson(doc, body);
+	if (err) {
+		sendApiCode(response, API_BAD_REQUEST, "Invalid JSON");
+		return;
+	}
+	String msg;
+		if (app.jsonproc.onSetOn(doc.as<JsonObject>(), msg, true)) {
+		sendApiCode(response, API_SUCCESS, "SetOn OK");
+	} else {
+		sendApiCode(response, API_BAD_REQUEST, msg);
+	}
+}
+
+void ApplicationWebserver::onSetOff(HttpRequest &request, HttpResponse &response) {
+	if(request.method == HTTP_OPTIONS) {
+		// probably a CORS request
+		setCorsHeaders(response);
+		sendApiCode(response, API_CODES::API_SUCCESS, "");
+		debug_i("HTTP_OPTIONS Request, sent API_SUCCESS");
+		return;
+	}
+	String body = request.getBody();
+	StaticJsonDocument<512> doc;
+	DeserializationError err = deserializeJson(doc, body);
+	if (err) {
+		sendApiCode(response, API_BAD_REQUEST, "Invalid JSON");
+		return;
+	}
+	String msg;
+		if (app.jsonproc.onSetOff(doc.as<JsonObject>(), msg, true)) {
+		sendApiCode(response, API_SUCCESS, "SetOff OK");
+	} else {
+		sendApiCode(response, API_BAD_REQUEST, msg);
+	}
 }
 
 void ApplicationWebserver::setCorsHeaders(HttpResponse& response)

--- a/include/eventserver.h
+++ b/include/eventserver.h
@@ -40,6 +40,7 @@ private:
     const unsigned long _minEventInterval = 500; // 500ms = 2 per second max
 	
 	ChannelOutput _lastRaw;
+	const HSVCT* _lastpHsv = nullptr;
 	// websocket interface
     ApplicationWebserver* webServer;
 	};

--- a/include/jsonprocessor.h
+++ b/include/jsonprocessor.h
@@ -12,36 +12,9 @@
  * pausing, continuing, blinking, toggling, and executing direct commands. It also supports
  * JSON-RPC commands.
  */
+
 class JsonProcessor {
 public:
-    bool onColor(const String& json, String& msg, bool relay = true);
-    bool onColor(JsonObject root, String& msg, bool relay = true);
-
-    bool onStop(const String& json, String& msg, bool relay = true);
-    bool onStop(JsonObject root, String& msg, bool relay = true);
-
-    bool onSkip(const String& json, String& msg, bool relay = true);
-    bool onSkip(JsonObject root, String& msg, bool relay = true);
-
-    bool onPause(const String& json, String& msg, bool relay = true);
-    bool onPause(JsonObject json, String& msg, bool relay = true);
-
-    bool onContinue(const String& json, String& msg, bool relay = true);
-    bool onContinue(JsonObject root, String& msg, bool relay = true);
-
-    bool onBlink(const String& json, String& msg, bool relay = true);
-    bool onBlink(JsonObject root, String& msg, bool relay = true);
-
-    bool onToggle(const String& json, String& msg, bool relay = true);
-    bool onToggle(JsonObject root, String& msg, bool relay = true);
-
-    bool onDirect(const String& json, String& msg, bool relay);
-    bool onDirect(JsonObject root, String& msg, bool relay);
-
-    bool onJsonRpc(const String& json);
-
-private:
-
     struct RequestParameters {
         String target;
 
@@ -76,6 +49,36 @@ private:
 
         int checkParams(String& errorMsg) const;
     };
+
+    bool onColor(const String& json, String& msg, bool relay = true);
+    bool onColor(JsonObject root, String& msg, bool relay = true);
+
+    bool onStop(const String& json, String& msg, bool relay = true);
+    bool onStop(JsonObject root, String& msg, bool relay = true);
+
+    bool onSkip(const String& json, String& msg, bool relay = true);
+    bool onSkip(JsonObject root, String& msg, bool relay = true);
+
+    bool onPause(const String& json, String& msg, bool relay = true);
+    bool onPause(JsonObject json, String& msg, bool relay = true);
+
+    bool onContinue(const String& json, String& msg, bool relay = true);
+    bool onContinue(JsonObject root, String& msg, bool relay = true);
+
+    bool onBlink(const String& json, String& msg, bool relay = true);
+    bool onBlink(JsonObject root, String& msg, bool relay = true);
+
+    // SetOn/SetOff API
+    bool onSetOn(JsonObject root, String& msg, bool relay = true);
+    bool onSetOff(JsonObject root, String& msg, bool relay = true);
+
+    bool onToggle(const String& json, String& msg, bool relay = true);
+    bool onToggle(JsonObject root, String& msg, bool relay = true);
+
+    bool onDirect(const String& json, String& msg, bool relay);
+    bool onDirect(JsonObject root, String& msg, bool relay);
+
+    bool onJsonRpc(const String& json);
 
     void parseRequestParams(JsonObject root, RequestParameters& params);
     void addChannelStatesToCmd(JsonObject root, const RGBWWLed::ChannelList& channels);

--- a/include/ledctrl.h
+++ b/include/ledctrl.h
@@ -1,3 +1,4 @@
+    
 /**
  * @file
  * @author  Patrick Jahns http://github.com/patrickjahns
@@ -23,6 +24,7 @@
 
 #include "mqtt.h"
 #include "stepsync.h"
+#include "jsonprocessor.h"
 
 #define APP_COLOR_FILE ".color"
 
@@ -52,6 +54,10 @@ public:
     void colorReset();
     void testChannels();
     void toggle();
+
+    // SetOn/SetOff with ramp, queue, and channel support
+    void setOn(const RGBWWLed::ChannelList& channels, int direction, const RampTimeOrSpeed& ramp, QueuePolicy queue, bool requeue, const String& name);
+    void setOff(const RGBWWLed::ChannelList& channels, int direction, const RampTimeOrSpeed& ramp, QueuePolicy queue, bool requeue, const String& name);
 
     void updateLed();
     void onMasterClock(uint32_t steps);

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -86,6 +86,10 @@ private:
     void onToggle(HttpRequest &request, HttpResponse &response);
     void onData(HttpRequest &request, HttpResponse &response);
     
+        // SetOn/SetOff endpoints
+    void onSetOn(HttpRequest &request, HttpResponse &response);
+    void onSetOff(HttpRequest &request, HttpResponse &response);
+
     void onColorGet(HttpRequest &request, HttpResponse &response);
     void onColorPost(HttpRequest &request, HttpResponse &response);
     bool onColorPostCmd(JsonObject& root, String& errorMsg);


### PR DESCRIPTION
still testing, proceed with care.
This PR implements API endpoints for /on and /off (they could of course also be json-rpc endpoints, that may still change) that switch the controller off and back to the last configured hsv / RAW light.
This is highly experimental at this point and mainly for my own testing.