### PR TITLE
Fix/char signdness

### DIFF
--- a/app/mdnsHandler.cpp
+++ b/app/mdnsHandler.cpp
@@ -167,7 +167,8 @@ bool mdnsHandler::onMessage(mDNS::Message& message)
         return false;
     }
 
-    const char* answerName = String(srv_answer->getName()).c_str();
+    const String answerNameString = String(srv_answer->getName());
+    const char* answerName = answerNameString.c_str();
 #ifdef DEBUG_MDNS
     debug_i("answerName: %ssearchName: %s", answerName, searchName.c_str());
 #endif

--- a/include/mdnsHandler.h
+++ b/include/mdnsHandler.h
@@ -55,9 +55,8 @@ namespace Util {
             }
 
             const char* replacement = nullptr;
-            unsigned char u_cp = (unsigned char)cp;
 
-            switch (u_cp) {
+            switch (cp) {
                 case 0xE4: case 0xC4: replacement = "ae"; break; // ä, Ä
                 case 0xF6: case 0xD6: replacement = "oe"; break; // ö, Ö
                 case 0xFC: case 0xDC: replacement = "ue"; break; // ü, Ü
@@ -84,13 +83,13 @@ namespace Util {
                     *write_ptr++ = *replacement++;
                     last_char_was_hyphen = false;
                 }
-            } else if (u_cp >= 'a' && u_cp <= 'z' || u_cp >= '0' && u_cp <= '9') {
-                *write_ptr++ = u_cp;
+            } else if (cp >= 'a' && cp <= 'z' || cp >= '0' && cp <= '9') {
+                *write_ptr++ = cp;
                 last_char_was_hyphen = false;
-            } else if (u_cp >= 'A' && u_cp <= 'Z') {
-                *write_ptr++ = tolower(u_cp);
+            } else if (cp >= 'A' && cp <= 'Z') {
+                *write_ptr++ = tolower(cp);
                 last_char_was_hyphen = false;
-            } else if (u_cp == ' ' || u_cp == '_' || u_cp == '-') {
+            } else if (cp == ' ' || cp == '_' || cp == '-') {
                 if (!last_char_was_hyphen) {
                     *write_ptr++ = '-';
                     last_char_was_hyphen = true;

--- a/include/mdnsHandler.h
+++ b/include/mdnsHandler.h
@@ -35,21 +35,36 @@ namespace Util {
             uint32_t cp = 0;
             int len = 0;
 
-            if ((unsigned char)read_ptr[0] < 0x80) {
-                cp = read_ptr[0];
+            const unsigned char* p = (const unsigned char*)read_ptr;
+            size_t remaining = (str + bufferSize) - read_ptr;
+
+            if (remaining > 0 && p[0] < 0x80) { // 0xxxxxxx
+                cp = p[0];
                 len = 1;
-            } else if ((unsigned char)read_ptr[0] >= 0xC2 && (unsigned char)read_ptr[0] <= 0xDF) {
-                if ((unsigned char)read_ptr[1] >= 0x80 && (unsigned char)read_ptr[1] <= 0xBF) {
-                    cp = ((read_ptr[0] & 0x1F) << 6) | (read_ptr[1] & 0x3F);
-                    len = 2;
+            } else if (remaining > 1 && (p[0] & 0xE0) == 0xC0) { // 110xxxxx 10xxxxxx
+                if ((p[1] & 0xC0) == 0x80) {
+                    cp = ((p[0] & 0x1F) << 6) | (p[1] & 0x3F);
+                    if (cp >= 0x80) { // Check for overlong encoding
+                        len = 2;
+                    }
                 }
-            } else if ((unsigned char)read_ptr[0] == 0xE1 && (unsigned char)read_ptr[1] == 0xBA && (unsigned char)read_ptr[2] == 0x9E) {
-                cp = 0x1E9E; // ẞ
-                len = 3;
+            } else if (remaining > 2 && (p[0] & 0xF0) == 0xE0) { // 1110xxxx 10xxxxxx 10xxxxxx
+                if ((p[1] & 0xC0) == 0x80 && (p[2] & 0xC0) == 0x80) {
+                    cp = ((p[0] & 0x0F) << 12) | ((p[1] & 0x3F) << 6) | (p[2] & 0x3F);
+                    if (cp >= 0x800) { // Check for overlong encoding
+                        len = 3;
+                    }
+                }
+            } else if (remaining > 3 && (p[0] & 0xF8) == 0xF0) { // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+                if ((p[1] & 0xC0) == 0x80 && (p[2] & 0xC0) == 0x80 && (p[3] & 0xC0) == 0x80) {
+                    cp = ((p[0] & 0x07) << 18) | ((p[1] & 0x3F) << 12) | ((p[2] & 0x3F) << 6) | (p[3] & 0x3F);
+                    if (cp >= 0x10000) { // Check for overlong encoding
+                        len = 4;
+                    }
+                }
             }
 
-
-            if (len == 0) { // Invalid UTF-8 sequence
+            if (len == 0) { // Invalid or incomplete UTF-8 sequence
                 read_ptr++;
                 continue;
             }

--- a/include/mdnsHandler.h
+++ b/include/mdnsHandler.h
@@ -55,8 +55,9 @@ namespace Util {
             }
 
             const char* replacement = nullptr;
+            unsigned char u_cp = (unsigned char)cp;
 
-            switch (cp) {
+            switch (u_cp) {
                 case 0xE4: case 0xC4: replacement = "ae"; break; // ä, Ä
                 case 0xF6: case 0xD6: replacement = "oe"; break; // ö, Ö
                 case 0xFC: case 0xDC: replacement = "ue"; break; // ü, Ü
@@ -83,13 +84,13 @@ namespace Util {
                     *write_ptr++ = *replacement++;
                     last_char_was_hyphen = false;
                 }
-            } else if (cp >= 'a' && cp <= 'z' || cp >= '0' && cp <= '9') {
-                *write_ptr++ = cp;
+            } else if (u_cp >= 'a' && u_cp <= 'z' || u_cp >= '0' && u_cp <= '9') {
+                *write_ptr++ = u_cp;
                 last_char_was_hyphen = false;
-            } else if (cp >= 'A' && cp <= 'Z') {
-                *write_ptr++ = tolower(cp);
+            } else if (u_cp >= 'A' && u_cp <= 'Z') {
+                *write_ptr++ = tolower(u_cp);
                 last_char_was_hyphen = false;
-            } else if (cp == ' ' || cp == '_' || cp == '-') {
+            } else if (u_cp == ' ' || u_cp == '_' || u_cp == '-') {
                 if (!last_char_was_hyphen) {
                     *write_ptr++ = '-';
                     last_char_was_hyphen = true;


### PR DESCRIPTION
the sanitizeHostname used a utf-8 decoding that relied on char being unsigned, esp32 char is signed, though, thus the replacement failed and jumbled up hostnames.
