### PR TITLE
Fix/deploy stable links

### DIFF
--- a/app/application.cpp
+++ b/app/application.cpp
@@ -149,8 +149,8 @@ void onReady()
 // Sming Framework INIT method - called during boot
 void init(){	
 
-
-	#ifdef UART_ID_SERIAL_USB_JTAG
+	// use the JTAG-USB serial for debug output if available
+	#ifdef UART_ID_SERIAL_USB_JTAG 
         Serial.setPort(UART_ID_SERIAL_USB_JTAG);
     #endif
 

--- a/app/application.cpp
+++ b/app/application.cpp
@@ -148,11 +148,21 @@ void onReady()
 
 // Sming Framework INIT method - called during boot
 void init(){	
+
+
+	#ifdef UART_ID_SERIAL_USB_JTAG
+        Serial.setPort(UART_ID_SERIAL_USB_JTAG);
+    #endif
+
+    Serial.begin(SERIAL_BAUD_RATE);
+    
+	Serial.systemDebugOutput(true);
+    
+	delay(500);
 	Serial.setTxBufferSize(1024);
 	Serial.setTxWait(false); // Make sure debug output doesn't stall
-	Serial.begin(SERIAL_BAUD_RATE);
 	Serial.systemDebugOutput(true);
-
+	
 	// System.setCpuFrequency(CpuCycleClockFast::cpuFrequency());
 
 	Serial.print(_F("Available heap: "));

--- a/component.mk
+++ b/component.mk
@@ -73,6 +73,8 @@ GIT_DATE = $(firstword $(shell git --no-pager show --date=short --format="%ad" -
 SMING_GITVERSION =	$(shell git -C $(SMING_HOME)/.. describe --abbrev=4 --dirty --always --tags)"-["$(shell git -C $(SMING_HOME)/.. rev-parse --abbrev-ref HEAD)"]"
 WEBAPP_VERSION = $(shell cat $(PROJECT_DIR)/webapp/VERSION)
 USER_CFLAGS = -DGITVERSION=\"$(GIT_VERSION)\" -DGITDATE=\"$(GIT_DATE)\" -DWEBAPP_VERSION=\"$(WEBAPP_VERSION)\" -DSMING_GITVERSION=\"$(SMING_GITVERSION)\" -DMQTT_USER=\"$(MQTT_USER)\" -DMQTT_PASS=\"$(MQTT_PASS)\"
+COMPONENT_CPPFLAGS += -DCONFIG_ESP_CONSOLE_USB_CDC=1
+
 
 #ifdef MDNS_DEBUG
 #    USER_CFLAGS += -DMDNS_DEBUG

--- a/manage_version.py
+++ b/manage_version.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import os
 import sys
@@ -7,6 +5,39 @@ import re
 import shutil
 import requests
 from urllib.parse import urlparse
+
+def update_latest_symlink(data, base_dir='download'):
+    """
+    For each branch (develop, testing, main), create or update a symlink (or copy) in download/latest-<branch>/app_merged.bin
+    pointing to the latest single_image/app_merged.bin for that branch.
+    """
+    branches = ['develop', 'testing', 'main']
+    for branch in branches:
+        # Find all firmware entries for this branch and single_image builds
+        candidates = [e for e in data['firmware'] if e['branch'] == branch and 'single_image' in e['files']['rom']['url']]
+        if not candidates:
+            continue
+        # Sort by version (descending)
+        candidates.sort(key=lambda e: extract_complete_version_number(e['fw_version']), reverse=True)
+        latest = candidates[0]
+        url = latest['files']['rom']['url']
+        # Extract the local path to app_merged.bin
+        parsed = urlparse(url)
+        rel_path = parsed.path.lstrip('/')
+        src_path = os.path.join(base_dir, rel_path) if not rel_path.startswith(base_dir) else rel_path
+        # Target symlink directory
+        link_dir = os.path.join(base_dir, f'latest-{branch}')
+        os.makedirs(link_dir, exist_ok=True)
+        link_path = os.path.join(link_dir, 'app_merged.bin')
+        # Remove old symlink or file if exists
+        if os.path.islink(link_path) or os.path.exists(link_path):
+            os.remove(link_path)
+        try:
+            os.symlink(os.path.abspath(src_path), link_path)
+            print(f"Created symlink: {link_path} -> {src_path}")
+        except Exception as e:
+            print(f"Failed to create symlink for {branch}: {e}")
+
 
 def load_json(file_path_or_url):
     # Check if the input is a URL
@@ -130,7 +161,7 @@ def add_or_update_entry(data, soc, type_, branch, fw_version, url):
             else:
                 # Same combination but different version - move to history
                 print(f"Moving {original_soc}/{original_type}/{original_branch}: {entry['fw_version']} to history")
-                # Create a copy to avoid reference issues
+                # Create a copy to avoid reference is=sues
                 history_entry = dict(entry)
                 data['history'].append(history_entry)
                 
@@ -234,6 +265,9 @@ def delete_entry(data, soc, type_, branch, fw_version=None, delete_files=False):
                                       entry['type'] == type_ and 
                                       entry['branch'] == branch)]
             
+# ...existing code...
+
+# Place this function after all imports, before main()
             entries_to_delete.extend(history_entries_to_delete)
     
     # Delete corresponding directories if requested
@@ -348,6 +382,9 @@ def cull_history(data, dry_run=False):
     print(f"  Total: {len(data['history'])} entries")
     
     entries_to_remove = []
+# ...existing code...
+
+# Place this function after all imports, before main()
     
     # Process each group
     for (soc, type_, branch), entries in grouped_entries.items():
@@ -431,57 +468,9 @@ def main():
     if data is None:
         if not (file_path_or_url.startswith('http://') or file_path_or_url.startswith('https://')):
             # Only create a new file if it's a local path
-            data = prime_json(file_path_or_url)
-        else:
-            print(f"Cannot retrieve data from URL: {file_path_or_url}")
-            return
-    
-    # Ensure history array exists in existing files
-    if "history" not in data:
-        data["history"] = []
-
-    # Handle read-only operations that work with both local files and URLs
-    if action == 'list':
-        if len(sys.argv) < 3:
-            print("Usage: script.py <json_file_or_url> list [soc] [type] [branch] [--history] [--check-urls]")
-            return
-        
-        soc = None
-        type_ = None
-        branch = None
-        include_history = False
-        check_urls = False
-        
-        # Parse arguments
-        for i in range(3, len(sys.argv)):
-            if sys.argv[i] == "--history":
-                include_history = True
-            elif sys.argv[i] == "--check-urls":
-                check_urls = True
-            elif soc is None:
-                soc = sys.argv[i]
-            elif type_ is None:
-                type_ = sys.argv[i]
-            elif branch is None:
-                branch = sys.argv[i]
-        
-        if check_urls:
-            print("Checking URL accessibility (this may take a moment)...")
-        
-        entries = list_entries(data, soc, type_, branch, include_history, check_urls)
-        print(f"Found {len(entries)} entries:")
-        for entry in sorted(entries, key=lambda e: (e['branch'], e['soc'], e['type'], extract_build_number(e['fw_version']), e.get('is_history', False)), reverse=True):
-            history_marker = "[HISTORY] " if entry.get('is_history', False) else ""
-            url_status = " [✓]" if check_urls and entry.get('url_accessible', False) else " [✗]" if check_urls else ""
-            print(f"{history_marker}{entry['soc']}/{entry['type']}/{entry['branch']}: {entry['fw_version']}{url_status} - {entry['files']['rom']['url']}")
-        return  # No need to save for list operation
-
-    # For actions that modify the data, ensure we're not working with a URL
-    if file_path_or_url.startswith('http://') or file_path_or_url.startswith('https://'):
-        print(f"Cannot modify a remote URL. Please download the file first.")
+            pass
         return
 
-    # Handle write operations (only for local files)
     if action == 'add':
         if len(sys.argv) < 8:
             print("Usage: script.py <json_file> add <soc> <type> <branch> <fw_version> <url>")
@@ -492,7 +481,12 @@ def main():
         fw_version = sys.argv[6]
         url = sys.argv[7]
         data = add_or_update_entry(data, soc, type_, branch, fw_version, url)
-    elif action == 'delete':
+        save_json(data, file_path_or_url)
+        update_latest_symlink(data)
+        print(f"Entry added/updated for {soc}/{type_}/{branch} version {fw_version}.")
+        return
+
+    if action == 'delete':
         if len(sys.argv) < 6:
             print("Usage: script.py <json_file> delete <soc> <type> <branch> [fw_version] [--keep-files]")
             return
@@ -500,33 +494,57 @@ def main():
         type_ = sys.argv[4]
         branch = sys.argv[5]
         fw_version = None
-        delete_files = True  # Default to deleting files
-        
-        # Check for optional arguments
-        for i in range(6, len(sys.argv)):
-            if sys.argv[i] == "--keep-files":
+        delete_files = True
+        for arg in sys.argv[6:]:
+            if arg == '--keep-files':
                 delete_files = False
-            elif not fw_version:  # First non-flag argument is fw_version
-                fw_version = sys.argv[i]
-        
+            elif not fw_version:
+                fw_version = arg
         data = delete_entry(data, soc, type_, branch, fw_version, delete_files)
-    elif action == 'cull':
-        # Parse arguments
-        dry_run = False
-        for i in range(3, len(sys.argv)):
-            if sys.argv[i] == "--dry-run":
-                dry_run = True
-                
-        print(f"Culling history entries (dry run: {dry_run})")
-        data = cull_history(data, dry_run)
-    else:
-        print("Invalid action. Use add, delete, list, or cull.")
+        save_json(data, file_path_or_url)
+        update_latest_symlink(data)
+        print(f"Entry deleted for {soc}/{type_}/{branch} version {fw_version}.")
         return
 
-    # Only save if we made changes and not in a dry run
-    if action in ['add', 'delete'] or (action == 'cull' and not dry_run):
-        save_json(data, file_path_or_url)
+    if action == 'cull':
+        dry_run = False
+        for arg in sys.argv[3:]:
+            if arg == '--dry-run':
+                dry_run = True
+        print(f"Culling history entries (dry run: {dry_run})")
+        data = cull_history(data, dry_run)
+        if not dry_run:
+            save_json(data, file_path_or_url)
+            update_latest_symlink(data)
+        return
 
+    if action == 'list':
+        soc = None
+        type_ = None
+        branch = None
+        include_history = False
+        check_urls = False
+        # Parse arguments
+        for arg in sys.argv[3:]:
+            if arg == '--history':
+                include_history = True
+            elif arg == '--check-urls':
+                check_urls = True
+            elif soc is None:
+                soc = arg
+            elif type_ is None:
+                type_ = arg
+            elif branch is None:
+                branch = arg
+        entries = list_entries(data, soc, type_, branch, include_history, check_urls)
+        print(f"Found {len(entries)} entries:")
+        for entry in sorted(entries, key=lambda e: (e['branch'], e['soc'], e['type'], extract_build_number(e['fw_version']), e.get('is_history', False)), reverse=True):
+            history_marker = "[HISTORY] " if entry.get('is_history', False) else ""
+            url_status = " [✓]" if check_urls and entry.get('url_accessible', False) else " [✗]" if check_urls else ""
+            print(f"{history_marker}{entry['soc']}/{entry['type']}/{entry['branch']}: {entry['fw_version']}{url_status} - {entry['files']['rom']['url']}")
+        return
+
+    print("Invalid action. Use add, delete, list, or cull.")
 
 if __name__ == "__main__":
     main()

--- a/test_manage_version.py
+++ b/test_manage_version.py
@@ -1,0 +1,110 @@
+def test_update_latest_symlink():
+    import os
+    from manage_version import update_latest_symlink
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Setup fake download structure
+        base_dir = os.path.join(tmpdir, 'download')
+        os.makedirs(base_dir)
+        # Simulate two builds for develop
+        build1 = os.path.join(base_dir, 'develop', 'build1', 'esp32', 'release', 'single_image')
+        build2 = os.path.join(base_dir, 'develop', 'build2', 'esp32', 'release', 'single_image')
+        os.makedirs(build1)
+        os.makedirs(build2)
+        # Create two app_merged.bin files
+        with open(os.path.join(build1, 'app_merged.bin'), 'w') as f:
+            f.write('old')
+        with open(os.path.join(build2, 'app_merged.bin'), 'w') as f:
+            f.write('new')
+        # Prepare data with two entries, latest is build2
+        data = {
+            'firmware': [
+                {
+                    'soc': 'esp32',
+                    'type': 'release',
+                    'branch': 'develop',
+                    'fw_version': 'V1.0-101',
+                    'files': {'rom': {'url': f'file://{os.path.join(build1, "app_merged.bin")}'}}
+                },
+                {
+                    'soc': 'esp32',
+                    'type': 'release',
+                    'branch': 'develop',
+                    'fw_version': 'V1.0-102',
+                    'files': {'rom': {'url': f'file://{os.path.join(build2, "app_merged.bin")}'}}
+                }
+            ],
+            'history': []
+        }
+        update_latest_symlink(data, base_dir=base_dir)
+        # Check that the symlink exists and points to the latest file
+        latest_link = os.path.join(base_dir, 'latest-develop', 'app_merged.bin')
+        assert os.path.islink(latest_link) or os.path.exists(latest_link)
+        with open(latest_link, 'r') as f:
+            content = f.read()
+        assert content == 'new'
+import os
+import tempfile
+import json
+import shutil
+import pytest
+from manage_version import (
+    add_or_update_entry,
+    delete_entry,
+    get_version_limit,
+    list_entries,
+    save_json,
+    load_json,
+    prime_json,
+    cull_history
+)
+
+def test_add_and_list_entry():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        json_path = os.path.join(tmpdir, 'test.json')
+        data = prime_json(json_path)
+        # Add entry
+        data = add_or_update_entry(data, 'esp32', 'release', 'develop', 'V1.0-100', 'http://example.com/rom0.bin')
+        save_json(data, json_path)
+        # Reload and list
+        data = load_json(json_path)
+        entries = list_entries(data, 'esp32', 'release', 'develop')
+        assert len(entries) == 1
+        assert entries[0]['fw_version'] == 'V1.0-100'
+        assert entries[0]['files']['rom']['url'] == 'http://example.com/rom0.bin'
+
+def test_delete_entry():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        json_path = os.path.join(tmpdir, 'test.json')
+        data = prime_json(json_path)
+        data = add_or_update_entry(data, 'esp32', 'release', 'develop', 'V1.0-100', 'http://example.com/rom0.bin')
+        save_json(data, json_path)
+        # Delete entry
+        data = delete_entry(data, 'esp32', 'release', 'develop', 'V1.0-100', delete_files=False)
+        save_json(data, json_path)
+        data = load_json(json_path)
+        entries = list_entries(data, 'esp32', 'release', 'develop')
+        assert len(entries) == 0
+
+def test_version_limit():
+    assert get_version_limit('stable') == 4
+    assert get_version_limit('testing') == 4
+    assert get_version_limit('develop') == 10
+    assert get_version_limit('foobar') == 10
+
+def test_cull_history():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        json_path = os.path.join(tmpdir, 'test.json')
+        data = prime_json(json_path)
+        # Add 12 versions to develop
+        for i in range(12):
+            v = f'V1.0-{100+i}'
+            data = add_or_update_entry(data, 'esp32', 'release', 'develop', v, f'http://example.com/rom{i}.bin')
+        save_json(data, json_path)
+        # Cull history
+        data = cull_history(data, dry_run=False)
+        save_json(data, json_path)
+        data = load_json(json_path)
+        entries = list_entries(data, 'esp32', 'release', 'develop', include_history=True)
+        # Should only keep 10 versions for develop
+        kept = [e for e in entries if not e.get('is_history', False)]
+        assert len(kept) <= 10


### PR DESCRIPTION
This commit addresses two unrelated things:
- it (hopefully) fixes the issue that the stable download links in the firmware download structure did not point to the current release.
- it enables uart output on esp32c3 sysetms with jtag