### PR TITLE
added a configuration setting to enable or disable loading google fonts

### DIFF
--- a/app-config.cfgdb
+++ b/app-config.cfgdb
@@ -36,6 +36,10 @@
         "current_pin_config_name":{
           "type":"string",
           "default":"mrpj"
+        },
+        "allow_web_icons":{
+          "type":"boolean",
+          "default":true
         }
       }
     },


### PR DESCRIPTION
in order to allow pure offline operation of the controller (well, the frontend), this change introduces a config parameter to the the ui whether to enable or disable the functionality to fetch google icons online. If this is disabled, no data will flow to google.
If enabled, google might see a http get with Browser type and ip address and the icon itself.