### PR TITLE
(fix) reconfigure rsyslog when relevant config is changed - saves a reboot

### DIFF
--- a/app/webserver.cpp
+++ b/app/webserver.cpp
@@ -495,9 +495,9 @@ void ApplicationWebserver::onConfig(HttpRequest& request, HttpResponse& response
 		app.telemetryClient.log(F("onConfig POST"));
 
 		/* ConfigDB importFomStream */
-		String oldIP, oldSSID, oldDeviceName, oldCurrentPinConfigName;
-		bool mqttEnabled, dhcpEnabled,rSyslogEnabled;
-		int oldColorMode;
+		String oldIP, oldSSID, oldDeviceName, oldCurrentPinConfigName, oldRsyslogHost;
+		bool mqttEnabled, dhcpEnabled,oldRSyslogEnabled;
+		int oldColorMode,oldRSyslogPort;
 		{
 			debug_i("ApplicationWebserver::onConfig storing old settings");
 			app.telemetryClient.log(F("onConfig storing old settings"));
@@ -505,7 +505,9 @@ void ApplicationWebserver::onConfig(HttpRequest& request, HttpResponse& response
 			oldIP = network.connection.getIp();
 			oldSSID = network.ap.getSsid();
 			mqttEnabled = network.mqtt.getEnabled();
-			rSyslogEnabled=network.rsyslog.getEnabled();
+			oldRSyslogEnabled=network.rsyslog.getEnabled();
+			oldRSyslogPort=network.rsyslog.getPort();
+			oldRsyslogHost=network.rsyslog.getHost();
 			dhcpEnabled=network.connection.getDhcp();
 		}
 		{
@@ -537,9 +539,9 @@ void ApplicationWebserver::onConfig(HttpRequest& request, HttpResponse& response
 			// bool restart = root[F("restart")] | false;
 
 			app.telemetryClient.start();
-			String newIP, newSSID, newDeviceName, newCurrentPinConfigName;
-			bool newMqttEnabled,newDhcpEnabled,newRsyslogEnabled;
-			int newColorMode;
+			String newIP, newSSID, newDeviceName, newCurrentPinConfigName, newRSyslogHost;
+			bool newMqttEnabled,newDhcpEnabled,newRSyslogEnabled;
+			int newColorMode,newRSyslogPort;
 			{
 				debug_i("ApplicationWebserver::onConfig getting new settings");
 				app.telemetryClient.log(F("onConfig getting new settings"));
@@ -548,8 +550,9 @@ void ApplicationWebserver::onConfig(HttpRequest& request, HttpResponse& response
 				newSSID = network.ap.getSsid();
 				newMqttEnabled = network.mqtt.getEnabled();
 				newDhcpEnabled=network.connection.getDhcp();
-				newRsyslogEnabled=network.rsyslog.getEnabled();
-
+				newRSyslogEnabled=network.rsyslog.getEnabled();
+				newRSyslogHost=network.rsyslog.getHost();
+				newRSyslogPort=network.rsyslog.getPort();
 			}
 			{
 				AppConfig::General general(*app.cfg);
@@ -629,9 +632,12 @@ void ApplicationWebserver::onConfig(HttpRequest& request, HttpResponse& response
 				//app.delayedCMD(F("restart"),1000);
 			}
 
-			if(rSyslogEnabled!=newRsyslogEnabled){
-				String msg = F("rsyslog settings changed - rebooting ");
-				app.udpSyslogStream.setStatus(newRsyslogEnabled);
+			if(oldRsyslogHost!=newRsyslogHost || oldRSyslogPort!=newRSyslogPort){
+				app.udpSyslogStream.begin(newRsyslogHost,newRSyslogPort);
+			}
+
+			if(oldRSyslogEnabled!=newRSyslogEnabled){
+				app.udpSyslogStream.setStatus(newRSyslogEnabled);
 			}
 
 			debug_i("ApplicationWebserver::onConfig %i, %i",newColorMode,oldColorMode);

--- a/include/udpSyslogStream.h
+++ b/include/udpSyslogStream.h
@@ -43,14 +43,15 @@ public:
     void begin(const String& host, uint16_t port = SYSLOG_PORT,
                const String& hostname = "rgbww",
                const String& tag = "app",
-               uint8_t priority = 191)
+               uint8_t priority = 191,
+               bool enabled=true)
     {
         _host     = host;
         _port     = port;
         _hostname = hostname;
         _tag      = tag;
         _priority = priority;
-        _enabled  = true;
+        _enabled  = enabled;
         _udp.connect(IpAddress(_host), _port);
 
         // Flush anything captured before begin().

--- a/include/udpSyslogStream.h
+++ b/include/udpSyslogStream.h
@@ -43,14 +43,15 @@ public:
     void begin(const String& host, uint16_t port = SYSLOG_PORT,
                const String& hostname = "rgbww",
                const String& tag = "app",
-               uint8_t priority = 191)
+               uint8_t priority = 191
+               bool enabled=true)
     {
         _host     = host;
         _port     = port;
         _hostname = hostname;
         _tag      = tag;
         _priority = priority;
-        _enabled  = true;
+        _enabled  = enabled;
         _udp.connect(IpAddress(_host), _port);
 
         // Flush anything captured before begin().


### PR DESCRIPTION
added an rsyslog feature to the controller firmware. This way, even controllers that are stuck behind a wall can provide useful log output as long as they can connect to a network.

the config page for rsyslog is under "network" - if you don't see it at first, <shift> reload the page to force cache bypassing.

to receive rsyslog on linux, add this configuration file to your `/etc/rsyslog.d/` - I named it lightinator.conf but any name will do
```
template(name="LightinatorLog" type="string" string="/var/log/lightinator.log")

template(name="LightinatorWithIP" type="list") {
    property(name="timegenerated" dateFormat="rfc3339")
    constant(value=" ")
    property(name="fromhost-ip")
    constant(value=" : ")
    property(name="rawmsg")
    constant(value="\n")
}

ruleset(name="LightinatorLogProcessing") {
    action(type="omfile" dynaFile="LightinatorLog" template="LightinatorWithIP")
    stop
}

module(load="imudp")
input(type="imudp" port="514" ruleset="LightinatorLogProcessing")
```
this will send lightinator output to `/var/log/lightinator.log` as well as add timestamp and the controller's ip address to every line. 
