### PR TITLE
Crash reporting: RTC memory stack capture + decode-stacktrace compatible output

### DIFF
--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -224,12 +224,40 @@ jobs:
             echo "artifact_name=lightinator-${{ matrix.soc }}-debug${tag}-${{ steps.sanitize_branch.outputs.sanitized_branch }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Set ELF path
+        id: set_elf_path
+        # Only for non-single-image builds: single images share the same ELF as their counterpart
+        if: ${{ matrix.single == 0 }}
+        run: |
+          if [ "${{ matrix.soc }}" = "esp8266" ] && [ "${{ matrix.release }}" = "0" ]; then
+            echo "elf=out/Esp8266/debug/build/app_0.out" >> $GITHUB_OUTPUT
+            echo "map=out/Esp8266/debug/build/app_0.map" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.soc }}" = "esp8266" ] && [ "${{ matrix.release }}" = "1" ]; then
+            echo "elf=out/Esp8266/release/build/app_0.out" >> $GITHUB_OUTPUT
+            echo "map=out/Esp8266/release/build/app_0.map" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.soc }}" = "esp32" ] && [ "${{ matrix.release }}" = "0" ]; then
+            echo "elf=out/Esp32/esp32/debug/build/app.out" >> $GITHUB_OUTPUT
+            echo "map=out/Esp32/esp32/debug/build/app.map" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.soc }}" = "esp32" ] && [ "${{ matrix.release }}" = "1" ]; then
+            echo "elf=out/Esp32/esp32/release/build/app.out" >> $GITHUB_OUTPUT
+            echo "map=out/Esp32/esp32/release/build/app.map" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.soc }}" = "esp32c3" ] && [ "${{ matrix.release }}" = "0" ]; then
+            echo "elf=out/Esp32/esp32c3/debug/build/app.out" >> $GITHUB_OUTPUT
+            echo "map=out/Esp32/esp32c3/debug/build/app.map" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.soc }}" = "esp32c3" ] && [ "${{ matrix.release }}" = "1" ]; then
+            echo "elf=out/Esp32/esp32c3/release/build/app.out" >> $GITHUB_OUTPUT
+            echo "map=out/Esp32/esp32c3/release/build/app.map" >> $GITHUB_OUTPUT
+          fi
+
       - name: Upload firmware artifact
         if: ${{ steps.set_firmware_path.outputs.path != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}
-          path: ${{ steps.set_firmware_path.outputs.path }}
+          path: |
+            ${{ steps.set_firmware_path.outputs.path }}
+            ${{ steps.set_elf_path.outputs.elf }}
+            ${{ steps.set_elf_path.outputs.map }}
           
       - name: Create version info file
         run: |

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -281,13 +281,24 @@ jobs:
           for soc in esp8266 esp32 esp32c3; do
             for type in debug release; do
               if [ "$soc" = "esp8266" ]; then
-                file="rom0.bin"
+                bin_file="rom0.bin"
+                elf_file="app_0.out"
+                map_file="app_0.map"
               else
-                file="app.bin"
+                bin_file="app.bin"
+                elf_file="app.out"
+                map_file="app.map"
               fi
               
-              url="http://$DEPLOY_SERVER/download/$TARGET_BRANCH/$VERSION/$soc/$type/$file"
+              url="http://$DEPLOY_SERVER/download/$TARGET_BRANCH/$VERSION/$soc/$type/$bin_file"
               python3 manage_version.py version.json add $soc $type $TARGET_BRANCH "$VERSION" "$url"
+              
+              # ELF and map are deployed as sibling files in the same directory.
+              # URL pattern: /download/{branch}/{version}/{soc}/{type}/{elf_file}
+              # The log service can derive these URLs from the rom URL without
+              # any version.json changes.
+              echo "ELF deployed at: http://$DEPLOY_SERVER/download/$TARGET_BRANCH/$VERSION/$soc/$type/$elf_file"
+              echo "MAP deployed at: http://$DEPLOY_SERVER/download/$TARGET_BRANCH/$VERSION/$soc/$type/$map_file"
             done
           done
           

--- a/app/application.cpp
+++ b/app/application.cpp
@@ -132,7 +132,7 @@ extern "C" void __wrap_user_pre_init(void)
 // Output format is compatible with Sming decode-stacktrace.py.
 #define CRASH_RTC_SLOT    64
 #define CRASH_RTC_MAGIC   0xDEADC0DEu
-#define CRASH_STACK_WORDS 53
+#define CRASH_STACK_WORDS 54
 
 struct CrashDump {
 	uint32_t magic;

--- a/app/application.cpp
+++ b/app/application.cpp
@@ -124,7 +124,52 @@ extern "C" void __wrap_user_pre_init(void)
 	__real_user_pre_init();
 }
 
-#endif
+// ─── Crash-dump capture via RTC user memory ──────────────────────────────────
+// RTC user area: slots 64-127, each 4 bytes → 256 bytes total.
+// Layout: magic(4) + reason(4) + exccause(4) + epc1(4) + epc2(4) + epc3(4)
+//         + excvaddr(4) + depc(4) + stackCount(4) + stackWords[54](216) = 252 bytes
+#define CRASH_RTC_SLOT    64
+#define CRASH_RTC_MAGIC   0xDEADC0DEu
+#define CRASH_STACK_WORDS 54
+
+struct CrashDump {
+	uint32_t magic;
+	uint32_t reason;
+	uint32_t exccause;
+	uint32_t epc1, epc2, epc3;
+	uint32_t excvaddr, depc;
+	uint32_t stackCount;
+	uint32_t stackWords[CRASH_STACK_WORDS];
+};
+static_assert(sizeof(CrashDump) <= 256, "CrashDump exceeds RTC user memory");
+
+static CrashDump g_crashDump;
+static bool g_crashDumpValid = false;
+
+// Overrides the weak alias in crash_handler.c — runs before the reset.
+// Keep it minimal: only SDK primitive writes are safe here.
+extern "C" void custom_crash_callback(struct rst_info* ri, uint32_t stack, uint32_t stack_end)
+{
+	CrashDump dump{};
+	dump.magic    = CRASH_RTC_MAGIC;
+	dump.reason   = ri->reason;
+	dump.exccause = ri->exccause;
+	dump.epc1     = ri->epc1;
+	dump.epc2     = ri->epc2;
+	dump.epc3     = ri->epc3;
+	dump.excvaddr = ri->excvaddr;
+	dump.depc     = ri->depc;
+
+	uint32_t count = 0;
+	for(uint32_t addr = stack; addr < stack_end && count < CRASH_STACK_WORDS; addr += 4) {
+		dump.stackWords[count++] = *reinterpret_cast<const uint32_t*>(addr);
+	}
+	dump.stackCount = count;
+
+	system_rtc_mem_write(CRASH_RTC_SLOT, &dump, sizeof(dump));
+}
+
+#endif // ARCH_ESP8266
 
 Application app;
 
@@ -142,6 +187,7 @@ void onReady()
 	app.rtc_info = system_get_rst_info();
 	
 #ifdef ARCH_ESP8266
+	app.readCrashDump();
 	osMessageInterceptor.begin(onOsMessage);
 	debug_i("starting os message interceptor");
 #endif
@@ -265,7 +311,6 @@ void Application::checkRam()
 		}
 		*/
 	}
-	
 	
 	if (app.rtc_info->reason!= 0 && !_reboot_reported){
 		_reboot_reported=true;	
@@ -621,6 +666,58 @@ void Application::logRestart(){
 	m_snprintf(msg, sizeof(msg), "restart, reason: %u, exccause: %u", 
 	           (unsigned int)app.rtc_info->reason, (unsigned int)app.rtc_info->exccause);
 	telemetryClient.log(msg);
+}
+
+#ifdef ARCH_ESP8266
+void Application::readCrashDump()
+{
+	CrashDump dump{};
+	system_rtc_mem_read(CRASH_RTC_SLOT, &dump, sizeof(dump));
+	if(dump.magic == CRASH_RTC_MAGIC) {
+		g_crashDump = dump;
+		g_crashDumpValid = true;
+		// clear magic so we don't re-report on the next boot
+		dump.magic = 0;
+		system_rtc_mem_write(CRASH_RTC_SLOT, &dump, sizeof(dump));
+	}
+}
+#endif
+
+void Application::reportCrashDump()
+{
+	bool fullDumpReported = false;
+#ifdef ARCH_ESP8266
+	if(g_crashDumpValid) {
+		g_crashDumpValid = false;
+		fullDumpReported = true;
+		debug_w("*** CRASH DUMP: reason=%u exccause=%u epc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x",
+		        g_crashDump.reason, g_crashDump.exccause,
+		        g_crashDump.epc1, g_crashDump.epc2, g_crashDump.epc3,
+		        g_crashDump.excvaddr, g_crashDump.depc);
+		for(uint32_t i = 0; i < g_crashDump.stackCount; i += 4) {
+			uint32_t rem = g_crashDump.stackCount - i;
+			if(rem >= 4) {
+				debug_w("  stack[%2u-%2u]: 0x%08x 0x%08x 0x%08x 0x%08x", i, i + 3,
+				        g_crashDump.stackWords[i], g_crashDump.stackWords[i + 1],
+				        g_crashDump.stackWords[i + 2], g_crashDump.stackWords[i + 3]);
+			} else {
+				for(uint32_t j = 0; j < rem; j++) {
+					debug_w("  stack[%2u]:     0x%08x", i + j, g_crashDump.stackWords[i + j]);
+				}
+			}
+		}
+	}
+#endif
+	// Fallback: emit reason/registers if we didn't already emit a full dump above.
+	// On ESP32 this is always the path (no crash callback available).
+	// On ESP8266 this fires only if the RTC magic was invalid (rare: RTC scrambled on hard reset).
+	if(!fullDumpReported && rtc_info != nullptr &&
+	   (rtc_info->reason == REASON_EXCEPTION_RST ||
+	    rtc_info->reason == REASON_SOFT_WDT_RST  ||
+	    rtc_info->reason == REASON_WDT_RST)) {
+		debug_w("*** CRASH REBOOT: reason=%u exccause=%u epc1=0x%08x excvaddr=0x%08x",
+		        rtc_info->reason, rtc_info->exccause, rtc_info->epc1, rtc_info->excvaddr);
+	}
 }
 void Application::restart()
 {

--- a/app/application.cpp
+++ b/app/application.cpp
@@ -127,10 +127,12 @@ extern "C" void __wrap_user_pre_init(void)
 // ─── Crash-dump capture via RTC user memory ──────────────────────────────────
 // RTC user area: slots 64-127, each 4 bytes → 256 bytes total.
 // Layout: magic(4) + reason(4) + exccause(4) + epc1(4) + epc2(4) + epc3(4)
-//         + excvaddr(4) + depc(4) + stackCount(4) + stackWords[54](216) = 252 bytes
+//         + excvaddr(4) + depc(4) + stackBase(4) + stackCount(4)
+//         + stackWords[53](212) = 256 bytes exactly
+// Output format is compatible with Sming decode-stacktrace.py.
 #define CRASH_RTC_SLOT    64
 #define CRASH_RTC_MAGIC   0xDEADC0DEu
-#define CRASH_STACK_WORDS 54
+#define CRASH_STACK_WORDS 53
 
 struct CrashDump {
 	uint32_t magic;
@@ -138,10 +140,11 @@ struct CrashDump {
 	uint32_t exccause;
 	uint32_t epc1, epc2, epc3;
 	uint32_t excvaddr, depc;
+	uint32_t stackBase;   // sp at crash time — needed for decode-stacktrace address column
 	uint32_t stackCount;
 	uint32_t stackWords[CRASH_STACK_WORDS];
 };
-static_assert(sizeof(CrashDump) <= 256, "CrashDump exceeds RTC user memory");
+static_assert(sizeof(CrashDump) == 256, "CrashDump must fit exactly in RTC user memory");
 
 static CrashDump g_crashDump;
 static bool g_crashDumpValid = false;
@@ -159,6 +162,7 @@ extern "C" void custom_crash_callback(struct rst_info* ri, uint32_t stack, uint3
 	dump.epc3     = ri->epc3;
 	dump.excvaddr = ri->excvaddr;
 	dump.depc     = ri->depc;
+	dump.stackBase = stack;
 
 	uint32_t count = 0;
 	for(uint32_t addr = stack; addr < stack_end && count < CRASH_STACK_WORDS; addr += 4) {
@@ -690,21 +694,24 @@ void Application::reportCrashDump()
 	if(g_crashDumpValid) {
 		g_crashDumpValid = false;
 		fullDumpReported = true;
-		debug_w("*** CRASH DUMP: reason=%u exccause=%u epc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x",
-		        g_crashDump.reason, g_crashDump.exccause,
-		        g_crashDump.epc1, g_crashDump.epc2, g_crashDump.epc3,
-		        g_crashDump.excvaddr, g_crashDump.depc);
-		for(uint32_t i = 0; i < g_crashDump.stackCount; i += 4) {
-			uint32_t rem = g_crashDump.stackCount - i;
-			if(rem >= 4) {
-				debug_w("  stack[%2u-%2u]: 0x%08x 0x%08x 0x%08x 0x%08x", i, i + 3,
-				        g_crashDump.stackWords[i], g_crashDump.stackWords[i + 1],
-				        g_crashDump.stackWords[i + 2], g_crashDump.stackWords[i + 3]);
-			} else {
-				for(uint32_t j = 0; j < rem; j++) {
-					debug_w("  stack[%2u]:     0x%08x", i + j, g_crashDump.stackWords[i + j]);
-				}
-			}
+		// Emit in the format that Sming decode-stacktrace.py recognises.
+		// "pc=" line puts the tool into IN_REGISTERS state.
+		debug_w("pc=0x%08x sp=0x%08x excvaddr=0x%08x",
+		        g_crashDump.epc1, g_crashDump.stackBase, g_crashDump.excvaddr);
+		// Emit remaining exception registers on a separate line
+		// (the tool picks these up as generic r00/r01 style or passes them through)
+		debug_w("epc2=0x%08x epc3=0x%08x exccause=%u depc=0x%08x reason=%u",
+		        g_crashDump.epc2, g_crashDump.epc3,
+		        g_crashDump.exccause, g_crashDump.depc, g_crashDump.reason);
+		// Stack dump in the format "xxxxxxxx:  XXXXXXXX XXXXXXXX XXXXXXXX XXXXXXXX"
+		debug_w("Stack dump:");
+		uint32_t addr = g_crashDump.stackBase;
+		for(uint32_t i = 0; i < g_crashDump.stackCount; i += 4, addr += 16) {
+			uint32_t w0 = g_crashDump.stackWords[i];
+			uint32_t w1 = (i + 1 < g_crashDump.stackCount) ? g_crashDump.stackWords[i + 1] : 0;
+			uint32_t w2 = (i + 2 < g_crashDump.stackCount) ? g_crashDump.stackWords[i + 2] : 0;
+			uint32_t w3 = (i + 3 < g_crashDump.stackCount) ? g_crashDump.stackWords[i + 3] : 0;
+			debug_w("%08x:  %08x %08x %08x %08x", addr, w0, w1, w2, w3);
 		}
 	}
 #endif

--- a/app/networking.cpp
+++ b/app/networking.cpp
@@ -346,11 +346,6 @@ void AppWIFI::_STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway)
 
 	{
 		AppConfig::Network network(*app.cfg);
-		/*
-		if(network.connection.getDhcp()) {
-			ipAddress = "dhcp";
-		}
-			*/
 		uint32_t id;
 		
 		id = (uint32_t)system_get_chip_id();	
@@ -364,6 +359,9 @@ void AppWIFI::_STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway)
 			app.mqttclient.start();
 		}
 	} // end ConfigDB network context
+
+	// After network is up, report any crash/watchdog reboot to the syslog target
+	app.reportCrashDump();
 }
 
 /**

--- a/include/application.h
+++ b/include/application.h
@@ -64,6 +64,7 @@ public:
     inline bool isFirstRun() { return _first_run; };
 
     void checkRam();
+    void reportCrashDump();
 #ifdef ARCH_ESP8266
     inline bool isTempBoot() { return _bootmode == MODE_TEMP_ROM; };
 #else
@@ -132,6 +133,9 @@ private:
     void listFiles();
     void logRestart();
     void pollResetButton();
+#ifdef ARCH_ESP8266
+    void readCrashDump();
+#endif
 
     Timer _systimer;
     int _bootmode = 0;

--- a/include/application.h
+++ b/include/application.h
@@ -66,6 +66,7 @@ public:
     void checkRam();
     void reportCrashDump();
 #ifdef ARCH_ESP8266
+    void readCrashDump();
     inline bool isTempBoot() { return _bootmode == MODE_TEMP_ROM; };
 #else
     bool isTempBoot() { return false; };
@@ -133,9 +134,6 @@ private:
     void listFiles();
     void logRestart();
     void pollResetButton();
-#ifdef ARCH_ESP8266
-    void readCrashDump();
-#endif
 
     Timer _systimer;
     int _bootmode = 0;


### PR DESCRIPTION
## Summary

Adds crash stack capture and post-reboot reporting via syslog.

### ESP8266
- **At crash time**: overrides \`custom_crash_callback\` (weak alias in Sming's \`crash_handler.c\`) to save a \`CrashDump\` struct to RTC user memory slots 64-127. No flash writes — safe in degraded post-exception state. Saves \`rst_info\` fields, stack base pointer, and 53 raw stack words (exactly 256 bytes).
- **On next boot**: \`readCrashDump()\` reads back the magic-guarded struct and clears it.
- **After network up** (\`_STAGotIP\`): \`reportCrashDump()\` emits via \`debug_w\` → syslog stream → log target.

### ESP32
No crash callback in Sming's ESP32 port. Falls back to \`rst_info\` from \`esp_reset_reason()\` — reason code only.

### Output format
Fully compatible with \`make decode-stacktrace\` (Sming's \`decode-stacktrace.py\`):
\`\`\`
pc=0x40201234 sp=0x3ffff350 excvaddr=0x00000000
epc2=0x... epc3=0x... exccause=3 depc=0x... reason=1
Stack dump:
3ffff350:  40201234 3ffef888 00000001 3ffef8c0
\`\`\`
Pipe a captured syslog file (message fields only) through \`make decode-stacktrace TRACE=<file>\`.

### No partition table changes
State is in RTC user memory only. The \`coredump\` partition already present on ESP32 is available for future expansion.

## Future: automatic decode in lightinator-log-service
Requires: (1) CI uploading \`.elf\` as release artifact keyed to \`fw_git_version\`, (2) log service detecting \`pc=0x... sp=0x...\` and buffering dump lines per source, (3) downloading ELF + running \`decode-stacktrace.py\` via the Sming container, (4) logging decoded frames back to Loki.