### PR TITLE
fix(mqtt): report correct color_mode in HA state messages

### DIFF
--- a/app/mqtt.cpp
+++ b/app/mqtt.cpp
@@ -573,13 +573,27 @@ void AppMqttClient::publishHAState(const ChannelOutput& raw, const HSVCT* pHsv) 
     // State and brightness - Use 0-100 scale as configured in discovery
     doc[F("state")] = v > 0 ? F("ON") : F("OFF");
     doc[F("brightness")] = (uint8_t)val_percent;  // V is already 0-100%, use directly
-    doc[F("color_mode")] = F("hs");  // Always include color_mode
-    
-    // Only include color if light is on
-    if (v > 0) {
-        JsonObject color_obj = doc.createNestedObject(F("color"));
-        color_obj[F("h")] = hue_degrees;   // 0-360 degrees
-        color_obj[F("s")] = sat_percent;   // 0-100 percent
+
+    // Report the correct color_mode: "color_temp" when CT is active on a white-capable
+    // device, otherwise "hs". Sending the wrong mode violates the HA MQTT JSON light
+    // contract and causes HA to ignore the state update.
+    int colorMode = getCurrentColorMode();
+    bool supportsCT = (colorMode == 1 || colorMode == 3); // RGBWW or RGBWWCW
+    if (supportsCT && ct > 0) {
+        // Convert firmware CT (0–100) back to mireds for HA
+        int mireds = 153 + ct * 217 / 100;
+        doc[F("color_mode")] = F("color_temp");
+        if (v > 0) {
+            doc[F("color_temp")] = mireds;
+        }
+    } else {
+        doc[F("color_mode")] = F("hs");
+        // Only include color if light is on
+        if (v > 0) {
+            JsonObject color_obj = doc.createNestedObject(F("color"));
+            color_obj[F("h")] = hue_degrees;   // 0-360 degrees
+            color_obj[F("s")] = sat_percent;   // 0-100 percent
+        }
     }
     
     String stateTopic = _haDiscoveryPrefix + F("/light/") + _haNodeId + F("/") + _haObjectId + F("/state");


### PR DESCRIPTION
publishHAState() always emitted 'color_mode: "hs"' regardless of whether the warm/cool-white channels were actually driving the output. This violates the HA MQTT JSON light contract: when 'color_temp' is in supported_color_modes, HA expects the state to carry 'color_mode: "color_temp"' and a 'color_temp' mireds value instead of an hs color object, otherwise the UI shows stale/incorrect state.

Changes:
- Check getCurrentColorMode() to determine whether the device supports colour temperature (RGBWW=1 or RGBWWCW=3)
- When CT support is present and the current CT value > 0, emit
    color_mode: 'color_temp', color_temp: <mireds>
  using the inverse of the mireds↔CT conversion (ct*217/100 + 153)
- Otherwise emit the existing 'color_mode: "hs"' with the color object