### PR TITLE
fix(mqtt): re-publish HA discovery config on every reconnect

### DIFF
--- a/app/mqtt.cpp
+++ b/app/mqtt.cpp
@@ -133,6 +133,10 @@ void AppMqttClient::start()
 
 int AppMqttClient::onConnected(MqttClient& client, mqtt_message_t* message){
 	debug_i("MQTT Broker connected!!");
+	// Reset discovery flag so config is re-published after a broker restart.
+	// Retained discovery messages can be lost when a broker restarts; re-publishing
+	// ensures HA always has a valid discovery payload.
+	_haConfigPublished = false;
 	{
 		AppConfig::Sync sync(*app.cfg);
 		if(sync.getClockSlaveEnabled()) {


### PR DESCRIPTION
_haConfigPublished was set to true after the first successful publish and never cleared, so if the MQTT broker restarted and lost its retained messages the firmware would not re-send the discovery payload. HA would then be unable to reconstruct the entity and the device would appear unavailable or missing from the integrations dashboard.

Fix: reset _haConfigPublished = false at the start of onConnected() so that publishHomeAssistantConfig() is called on every reconnection.