### PR TITLE
feat(webappota): background webapp OTA, LittleFS-first delivery, CI minimal embed

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,5 +1,8 @@
 name: Build Container
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   schedule:
     - cron: "2 10 * * *" # Runs daily at 2:10  UTC

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -3,6 +3,9 @@ name: firmwareBuild
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [stable, testing, develop, experimental]

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -35,12 +35,13 @@ jobs:
       - name: Define supported SOCs
         id: set
         run: |
-          echo 'soc_json=["esp8266","esp32","esp32c3"]' >> $GITHUB_OUTPUT
-          echo 'soc_csv=esp8266,esp32,esp32c3' >> $GITHUB_OUTPUT
+          echo 'soc_json=["esp8266","esp32","esp32c3", "esp32c6"]' >> $GITHUB_OUTPUT
+          echo 'soc_csv=esp8266,esp32,esp32c3,esp32c6' >> $GITHUB_OUTPUT
 
-  host-build:
+  host-smoke:
+
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - name: Determine branch
         id: get_branch
@@ -158,110 +159,6 @@ jobs:
             echo "run_attempt=${{ github.run_attempt }}"
           } > out/host-ci/ci-bootstrap.txt
 
-      - name: Run Host build in Docker Container
-        env:
-          MQTT_PASS: ${{ secrets.MQTT_PASS }}
-          MQTT_USER: ${{ secrets.MQTT_USER }}
-          GITHUB_ACTIONS: 'true'
-        run: |
-          set -euo pipefail
-          mkdir -p out/host-ci
-          echo "Starting Host build at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
-          (while true; do sleep 30; echo "[host-build][heartbeat] $(date -u +%Y-%m-%dT%H:%M:%SZ)"; done) &
-          HEARTBEAT_PID=$!
-          trap 'kill "$HEARTBEAT_PID" 2>/dev/null || true' EXIT
-
-          set +e
-          docker run --rm --privileged -v ${{ github.workspace }}:/workspace -w /workspace \
-            -e GITHUB_RUN_NUMBER=${{ github.run_number }} \
-            -e GITHUB_ACTIONS=${{ env.GITHUB_ACTIONS }} \
-            -e MQTT_PASS=${{ secrets.MQTT_PASS }} \
-            -e MQTT_USER=${{ secrets.MQTT_USER }} \
-            -e HOST_CI_BUILD_ONLY=1 \
-            docker.io/pjakobs/sming:latest \
-            bash -lc "git config --global --add safe.directory /workspace && bash ./.github/scripts/host_ci_smoke_test.sh" \
-            2>&1 | tee out/host-ci/docker-build.log
-          docker_exit_code=${PIPESTATUS[0]}
-          set -e
-
-          echo "$docker_exit_code" > out/host-ci/docker-build.exitcode
-          echo "Host build finished with exit code: $docker_exit_code"
-          exit "$docker_exit_code"
-
-      - name: Upload Host firmware artifact
-        if: success()
-        uses: actions/upload-artifact@v7
-        with:
-          name: host-firmware-${{ steps.sanitize_branch.outputs.sanitized_branch }}
-          path: |
-            out/Host/debug/firmware/app
-            out/Host/debug/firmware/partitions.bin
-            out/Host/debug/config.mk
-            out/host-ci/build-output.txt
-            out/host-ci/build-warnings.txt
-          if-no-files-found: error
-          retention-days: 1
-
-  host-test:
-    needs: [host-build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Determine branch
-        id: get_branch
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "branch=${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "repository_dispatch" ]; then
-            echo "branch=${{ github.event.client_payload.branch }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "push" ]; then
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
-          else
-            echo "branch=develop" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Sanitize branch name for artifact
-        id: sanitize_branch
-        run: |
-          BRANCH="${{ steps.get_branch.outputs.branch }}"
-          SANITIZED_BRANCH=${BRANCH//\//-}
-          SANITIZED_BRANCH=${SANITIZED_BRANCH//\\/-}
-          SANITIZED_BRANCH=${SANITIZED_BRANCH//\?/-}
-          SANITIZED_BRANCH=${SANITIZED_BRANCH//\:/-}
-          SANITIZED_BRANCH=${SANITIZED_BRANCH//\*/-}
-          SANITIZED_BRANCH=${SANITIZED_BRANCH//\"/-}
-          SANITIZED_BRANCH=${SANITIZED_BRANCH//\</-}
-          SANITIZED_BRANCH=${SANITIZED_BRANCH//\>/-}
-          SANITIZED_BRANCH=${SANITIZED_BRANCH//\|/-}
-          echo "sanitized_branch=$SANITIZED_BRANCH" >> $GITHUB_OUTPUT
-
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ steps.get_branch.outputs.branch }}
-          fetch-depth: 0
-
-      - name: Download Host firmware artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: host-firmware-${{ steps.sanitize_branch.outputs.sanitized_branch }}
-          path: ${{ github.workspace }}/out
-
-      - name: Prepare host-ci artifact directory
-        if: always()
-        run: |
-          mkdir -p out/host-ci
-          chmod +x out/Host/debug/firmware/app || true
-          {
-            echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "branch=${{ steps.get_branch.outputs.branch }}"
-            echo "run_id=${{ github.run_id }}"
-            echo "run_attempt=${{ github.run_attempt }}"
-          } >> out/host-ci/ci-bootstrap.txt
-
       - name: Run Host smoke test in Docker Container
         env:
           MQTT_PASS: ${{ secrets.MQTT_PASS }}
@@ -269,11 +166,23 @@ jobs:
           GITHUB_ACTIONS: 'true'
         run: |
           set -euo pipefail
-          echo "Starting Host smoke tests at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          mkdir -p out/host-ci
+          echo "Starting Host smoke test at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-          (while true; do sleep 20; echo "[host-test][heartbeat] $(date -u +%Y-%m-%dT%H:%M:%SZ)"; done) &
+          # Emit periodic output so the job never looks stalled.
+          (
+            while true; do
+              sleep 20
+              echo "[host-smoke][heartbeat] $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            done
+          ) &
           HEARTBEAT_PID=$!
-          trap 'kill "$HEARTBEAT_PID" 2>/dev/null || true' EXIT
+
+          cleanup_heartbeat() {
+            kill "$HEARTBEAT_PID" >/dev/null 2>&1 || true
+            wait "$HEARTBEAT_PID" >/dev/null 2>&1 || true
+          }
+          trap cleanup_heartbeat EXIT
 
           set +e
           docker run --rm --privileged -v ${{ github.workspace }}:/workspace -w /workspace \
@@ -281,9 +190,8 @@ jobs:
             -e GITHUB_ACTIONS=${{ env.GITHUB_ACTIONS }} \
             -e MQTT_PASS=${{ secrets.MQTT_PASS }} \
             -e MQTT_USER=${{ secrets.MQTT_USER }} \
-            -e HOST_CI_SKIP_BUILD=1 \
-            ubuntu:22.04 \
-            bash -c "apt-get update -q && DEBIAN_FRONTEND=noninteractive apt-get install -y apt-utils python3 python3-pip python3-pytest python3-requests iproute2 lib32stdc++6 lib32z1 && pip3 install --quiet --timeout 60 --retries 5 pytest-md && bash ./.github/scripts/host_ci_smoke_test.sh" \
+            docker.io/pjakobs/sming:latest \
+            bash -lc "git config --global --add safe.directory /workspace && bash ./.github/scripts/host_ci_smoke_test.sh" \
             2>&1 | tee out/host-ci/docker-smoke.log
           docker_exit_code=${PIPESTATUS[0]}
           set -e
@@ -293,7 +201,14 @@ jobs:
 
           if [ "$docker_exit_code" -ne 0 ]; then
             echo "::group::Host smoke failure context"
-            tail -n 200 out/host-ci/docker-smoke.log || true
+            if [ -f out/host-ci/host-smoke.log ]; then
+              echo "--- tail out/host-ci/host-smoke.log ---"
+              tail -n 200 out/host-ci/host-smoke.log || true
+            fi
+            if [ -f out/host-ci/docker-smoke.log ]; then
+              echo "--- tail out/host-ci/docker-smoke.log ---"
+              tail -n 200 out/host-ci/docker-smoke.log || true
+            fi
             echo "::endgroup::"
           fi
 
@@ -483,7 +398,7 @@ jobs:
           echo "- Valgrind runtime startup log (RGBWW): valgrind-runtime-rgbww-startup.log" >> "$GITHUB_STEP_SUMMARY"
 
   build:
-    needs: [generate-matrix, host-test]
+    needs: [generate-matrix, host-smoke]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -142,22 +142,22 @@ jobs:
       - name: Download webapp files artifact
         run: |
           WEBAPP_BRANCH="${{ steps.map_webapp_branch.outputs.webapp_branch }}"
-          if [ -d ./webapp ]; then
-            rm -rf ./webapp
-          fi
-          mkdir -p ./webapp
           artifact_url="https://pljakobs.github.io/esp_rgb_webapp2/${WEBAPP_BRANCH}/spa-files.zip"
           echo "Downloading webapp files from: $artifact_url"
           curl -L -o spa-files.zip "$artifact_url"
           if [ "$WEBAPP_BRANCH" = "experimental" ]; then
             echo "experimental build: extracting minimal file set only"
-            mkdir -p ./webapp/config
             # captive.html and updating.html are committed in the firmware repo
-            # (tracked via .gitignore exception) — no extraction needed.
+            # (checked out above) — keep the webapp/ dir as-is so those files survive.
             # Only pull config/pinconfig.json and VERSION from the webapp zip.
+            mkdir -p ./webapp/config
             unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
             unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
           else
+            if [ -d ./webapp ]; then
+              rm -rf ./webapp
+            fi
+            mkdir -p ./webapp
             unzip spa-files.zip -d ./webapp
             mv ./webapp/dist/spa/* ./webapp
             rm -rf ./webapp/dist/spa
@@ -612,23 +612,23 @@ jobs:
       - name: Download webapp files artifact
         run: |
           WEBAPP_BRANCH="${{ steps.map_webapp_branch.outputs.webapp_branch }}"
-          if [ -d ./webapp ]; then
-            echo "removing and re-creating webapp directory"
-            rm -rf ./webapp
-          fi
-          mkdir -p ./webapp
           artifact_url="https://pljakobs.github.io/esp_rgb_webapp2/${WEBAPP_BRANCH}/spa-files.zip"
           echo "Downloading webapp files from: $artifact_url"
           curl -L -o spa-files.zip "$artifact_url"
           if [ "$WEBAPP_BRANCH" = "experimental" ]; then
             echo "experimental build: extracting minimal file set only"
-            mkdir -p ./webapp/config
             # captive.html and updating.html are committed in the firmware repo
-            # (tracked via .gitignore exception) — no extraction needed.
+            # (checked out above) — keep the webapp/ dir as-is so those files survive.
             # Only pull config/pinconfig.json and VERSION from the webapp zip.
+            mkdir -p ./webapp/config
             unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
             unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
           else
+            if [ -d ./webapp ]; then
+              echo "removing and re-creating webapp directory"
+              rm -rf ./webapp
+            fi
+            mkdir -p ./webapp
             unzip spa-files.zip -d ./webapp
             mv ./webapp/dist/spa/* ./webapp
             rm -rf ./webapp/dist/spa

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Define supported SOCs
         id: set
         run: |
-          echo 'soc_json=["esp8266","esp32","esp32c3", "esp32c6"]' >> $GITHUB_OUTPUT
-          echo 'soc_csv=esp8266,esp32,esp32c3,esp32c6' >> $GITHUB_OUTPUT
+          echo 'soc_json=["esp8266","esp32","esp32c3"]' >> $GITHUB_OUTPUT
+          echo 'soc_csv=esp8266,esp32,esp32c3' >> $GITHUB_OUTPUT
 
   host-smoke:
 

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -152,10 +152,10 @@ jobs:
           if [ "$WEBAPP_BRANCH" = "experimental" ]; then
             echo "experimental build: extracting minimal file set only"
             mkdir -p ./webapp/config
-            unzip -p spa-files.zip dist/spa/captive.html > ./webapp/captive.html
-            unzip -p spa-files.zip dist/spa/updating.html > ./webapp/updating.html
-            unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
-            unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
+            unzip -p spa-files.zip captive.html > ./webapp/captive.html
+            unzip -p spa-files.zip updating.html > ./webapp/updating.html
+            unzip -p spa-files.zip config/pinconfig.json > ./webapp/config/pinconfig.json
+            unzip -p spa-files.zip VERSION > ./webapp/VERSION
           else
             unzip spa-files.zip -d ./webapp
             mv ./webapp/dist/spa/* ./webapp
@@ -622,10 +622,10 @@ jobs:
           if [ "$WEBAPP_BRANCH" = "experimental" ]; then
             echo "experimental build: extracting minimal file set only"
             mkdir -p ./webapp/config
-            unzip -p spa-files.zip dist/spa/captive.html > ./webapp/captive.html
-            unzip -p spa-files.zip dist/spa/updating.html > ./webapp/updating.html
-            unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
-            unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
+            unzip -p spa-files.zip captive.html > ./webapp/captive.html
+            unzip -p spa-files.zip updating.html > ./webapp/updating.html
+            unzip -p spa-files.zip config/pinconfig.json > ./webapp/config/pinconfig.json
+            unzip -p spa-files.zip VERSION > ./webapp/VERSION
           else
             unzip spa-files.zip -d ./webapp
             mv ./webapp/dist/spa/* ./webapp

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -152,10 +152,23 @@ jobs:
           if [ "$WEBAPP_BRANCH" = "experimental" ]; then
             echo "experimental build: extracting minimal file set only"
             mkdir -p ./webapp/config
-            unzip -p spa-files.zip captive.html > ./webapp/captive.html
-            unzip -p spa-files.zip updating.html > ./webapp/updating.html
-            unzip -p spa-files.zip config/pinconfig.json > ./webapp/config/pinconfig.json
-            unzip -p spa-files.zip VERSION > ./webapp/VERSION
+            # captive.html and updating.html live at the webapp repo root and
+            # may not be present in the dist/spa zip. Try the zip first, then
+            # fall back to raw.githubusercontent.com.
+            if unzip -p spa-files.zip dist/spa/captive.html > ./webapp/captive.html 2>/dev/null; then
+              echo "captive.html from zip"
+            else
+              echo "captive.html not in zip, fetching from webapp repo"
+              curl -fsSL "https://raw.githubusercontent.com/pljakobs/esp_rgb_webapp2/${WEBAPP_BRANCH}/captive.html" > ./webapp/captive.html
+            fi
+            if unzip -p spa-files.zip dist/spa/updating.html > ./webapp/updating.html 2>/dev/null; then
+              echo "updating.html from zip"
+            else
+              echo "updating.html not in zip, fetching from webapp repo"
+              curl -fsSL "https://raw.githubusercontent.com/pljakobs/esp_rgb_webapp2/${WEBAPP_BRANCH}/updating.html" > ./webapp/updating.html
+            fi
+            unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
+            unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
           else
             unzip spa-files.zip -d ./webapp
             mv ./webapp/dist/spa/* ./webapp
@@ -622,10 +635,23 @@ jobs:
           if [ "$WEBAPP_BRANCH" = "experimental" ]; then
             echo "experimental build: extracting minimal file set only"
             mkdir -p ./webapp/config
-            unzip -p spa-files.zip captive.html > ./webapp/captive.html
-            unzip -p spa-files.zip updating.html > ./webapp/updating.html
-            unzip -p spa-files.zip config/pinconfig.json > ./webapp/config/pinconfig.json
-            unzip -p spa-files.zip VERSION > ./webapp/VERSION
+            # captive.html and updating.html live at the webapp repo root and
+            # may not be present in the dist/spa zip. Try the zip first, then
+            # fall back to raw.githubusercontent.com.
+            if unzip -p spa-files.zip dist/spa/captive.html > ./webapp/captive.html 2>/dev/null; then
+              echo "captive.html from zip"
+            else
+              echo "captive.html not in zip, fetching from webapp repo"
+              curl -fsSL "https://raw.githubusercontent.com/pljakobs/esp_rgb_webapp2/${WEBAPP_BRANCH}/captive.html" > ./webapp/captive.html
+            fi
+            if unzip -p spa-files.zip dist/spa/updating.html > ./webapp/updating.html 2>/dev/null; then
+              echo "updating.html from zip"
+            else
+              echo "updating.html not in zip, fetching from webapp repo"
+              curl -fsSL "https://raw.githubusercontent.com/pljakobs/esp_rgb_webapp2/${WEBAPP_BRANCH}/updating.html" > ./webapp/updating.html
+            fi
+            unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
+            unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
           else
             unzip spa-files.zip -d ./webapp
             mv ./webapp/dist/spa/* ./webapp

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -152,21 +152,9 @@ jobs:
           if [ "$WEBAPP_BRANCH" = "experimental" ]; then
             echo "experimental build: extracting minimal file set only"
             mkdir -p ./webapp/config
-            # captive.html and updating.html live at the webapp repo root and
-            # may not be present in the dist/spa zip. Try the zip first, then
-            # fall back to raw.githubusercontent.com.
-            if unzip -p spa-files.zip dist/spa/captive.html > ./webapp/captive.html 2>/dev/null; then
-              echo "captive.html from zip"
-            else
-              echo "captive.html not in zip, fetching from webapp repo"
-              curl -fsSL "https://raw.githubusercontent.com/pljakobs/esp_rgb_webapp2/${WEBAPP_BRANCH}/captive.html" > ./webapp/captive.html
-            fi
-            if unzip -p spa-files.zip dist/spa/updating.html > ./webapp/updating.html 2>/dev/null; then
-              echo "updating.html from zip"
-            else
-              echo "updating.html not in zip, fetching from webapp repo"
-              curl -fsSL "https://raw.githubusercontent.com/pljakobs/esp_rgb_webapp2/${WEBAPP_BRANCH}/updating.html" > ./webapp/updating.html
-            fi
+            # captive.html and updating.html are committed in the firmware repo
+            # (tracked via .gitignore exception) — no extraction needed.
+            # Only pull config/pinconfig.json and VERSION from the webapp zip.
             unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
             unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
           else
@@ -635,21 +623,9 @@ jobs:
           if [ "$WEBAPP_BRANCH" = "experimental" ]; then
             echo "experimental build: extracting minimal file set only"
             mkdir -p ./webapp/config
-            # captive.html and updating.html live at the webapp repo root and
-            # may not be present in the dist/spa zip. Try the zip first, then
-            # fall back to raw.githubusercontent.com.
-            if unzip -p spa-files.zip dist/spa/captive.html > ./webapp/captive.html 2>/dev/null; then
-              echo "captive.html from zip"
-            else
-              echo "captive.html not in zip, fetching from webapp repo"
-              curl -fsSL "https://raw.githubusercontent.com/pljakobs/esp_rgb_webapp2/${WEBAPP_BRANCH}/captive.html" > ./webapp/captive.html
-            fi
-            if unzip -p spa-files.zip dist/spa/updating.html > ./webapp/updating.html 2>/dev/null; then
-              echo "updating.html from zip"
-            else
-              echo "updating.html not in zip, fetching from webapp repo"
-              curl -fsSL "https://raw.githubusercontent.com/pljakobs/esp_rgb_webapp2/${WEBAPP_BRANCH}/updating.html" > ./webapp/updating.html
-            fi
+            # captive.html and updating.html are committed in the firmware repo
+            # (tracked via .gitignore exception) — no extraction needed.
+            # Only pull config/pinconfig.json and VERSION from the webapp zip.
             unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
             unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
           else

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -126,13 +126,17 @@ jobs:
       - name: Download fileList.h artifact
         run: |
           WEBAPP_BRANCH="${{ steps.map_webapp_branch.outputs.webapp_branch }}"
-          if [ -f ./include/fileList.h ]; then
-            rm ./include/fileList.h
+          if [ "$WEBAPP_BRANCH" = "experimental" ]; then
+            echo "experimental build: keeping repo fileList.h (minimal embed set)"
+          else
+            if [ -f ./include/fileList.h ]; then
+              rm ./include/fileList.h
+            fi
+            artifact_url="https://pljakobs.github.io/esp_rgb_webapp2/${WEBAPP_BRANCH}/fileList.h"
+            echo "Downloading fileList.h from: $artifact_url"
+            curl -L -o fileList.h "$artifact_url"
+            mv fileList.h ./include
           fi
-          artifact_url="https://pljakobs.github.io/esp_rgb_webapp2/${WEBAPP_BRANCH}/fileList.h"
-          echo "Downloading fileList.h from: $artifact_url"
-          curl -L -o fileList.h "$artifact_url"
-          mv fileList.h ./include
 
       - name: Download webapp files artifact
         run: |
@@ -144,9 +148,19 @@ jobs:
           artifact_url="https://pljakobs.github.io/esp_rgb_webapp2/${WEBAPP_BRANCH}/spa-files.zip"
           echo "Downloading webapp files from: $artifact_url"
           curl -L -o spa-files.zip "$artifact_url"
-          unzip spa-files.zip -d ./webapp
-          mv ./webapp/dist/spa/* ./webapp
-          rm -rf ./webapp/dist/spa
+          if [ "$WEBAPP_BRANCH" = "experimental" ]; then
+            echo "experimental build: extracting minimal file set only"
+            mkdir -p ./webapp/config
+            unzip -p spa-files.zip dist/spa/captive.html > ./webapp/captive.html
+            unzip -p spa-files.zip dist/spa/updating.html > ./webapp/updating.html
+            unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
+            unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
+          else
+            unzip spa-files.zip -d ./webapp
+            mv ./webapp/dist/spa/* ./webapp
+            rm -rf ./webapp/dist/spa
+          fi
+          rm spa-files.zip
           echo "webapp files version"
           cat ./webapp/VERSION
 
@@ -580,14 +594,18 @@ jobs:
       - name: Download fileList.h artifact
         run: |
           WEBAPP_BRANCH="${{ steps.map_webapp_branch.outputs.webapp_branch }}"
-          if [ -f ./include/fileList.h ]; then
-            echo "removing fileList.h"
-            rm ./include/fileList.h
+          if [ "$WEBAPP_BRANCH" = "experimental" ]; then
+            echo "experimental build: keeping repo fileList.h (minimal embed set)"
+          else
+            if [ -f ./include/fileList.h ]; then
+              echo "removing fileList.h"
+              rm ./include/fileList.h
+            fi
+            artifact_url="https://pljakobs.github.io/esp_rgb_webapp2/${WEBAPP_BRANCH}/fileList.h"
+            echo "Downloading fileList.h from: $artifact_url"
+            curl -L -o fileList.h "$artifact_url"
+            mv fileList.h ./include
           fi
-          artifact_url="https://pljakobs.github.io/esp_rgb_webapp2/${WEBAPP_BRANCH}/fileList.h"
-          echo "Downloading fileList.h from: $artifact_url"
-          curl -L -o fileList.h "$artifact_url"
-          mv fileList.h ./include
 
       - name: Download webapp files artifact
         run: |
@@ -595,14 +613,24 @@ jobs:
           if [ -d ./webapp ]; then
             echo "removing and re-creating webapp directory"
             rm -rf ./webapp
-            mkdir ./webapp
           fi
+          mkdir -p ./webapp
           artifact_url="https://pljakobs.github.io/esp_rgb_webapp2/${WEBAPP_BRANCH}/spa-files.zip"
           echo "Downloading webapp files from: $artifact_url"
           curl -L -o spa-files.zip "$artifact_url"
-          unzip spa-files.zip -d ./webapp
-          mv ./webapp/dist/spa/* ./webapp
-          rm -rf ./webapp/dist/spa
+          if [ "$WEBAPP_BRANCH" = "experimental" ]; then
+            echo "experimental build: extracting minimal file set only"
+            mkdir -p ./webapp/config
+            unzip -p spa-files.zip dist/spa/captive.html > ./webapp/captive.html
+            unzip -p spa-files.zip dist/spa/updating.html > ./webapp/updating.html
+            unzip -p spa-files.zip dist/spa/config/pinconfig.json > ./webapp/config/pinconfig.json
+            unzip -p spa-files.zip dist/spa/VERSION > ./webapp/VERSION
+          else
+            unzip spa-files.zip -d ./webapp
+            mv ./webapp/dist/spa/* ./webapp
+            rm -rf ./webapp/dist/spa
+          fi
+          rm spa-files.zip
           echo "webapp files version"
           cat ./webapp/VERSION
 

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -8,9 +8,9 @@ env:
 
 on:
   push:
-    branches: [stable, testing, develop, experimental]
+    branches: [stable, testing, develop, experimental, experimental-externalUI]
   pull_request:
-    branches: [stable, testing, develop, experimental]
+    branches: [stable, testing, develop, experimental, experimental-externalUI]
   repository_dispatch:
     types: [frontend-build-completed]
   workflow_dispatch:
@@ -25,6 +25,7 @@ on:
           - testing
           - develop
           - experimental
+          - experimental-externalUI
 
 jobs:
   # Single source of truth for supported SOCs.
@@ -75,7 +76,7 @@ jobs:
             "stable")
               WEBAPP_BRANCH="stable"
               ;;
-            "experimental")
+            "experimental"|"experimental-externalUI")
               WEBAPP_BRANCH="experimental"
               ;;
             *)
@@ -454,7 +455,7 @@ jobs:
             "stable")
               WEBAPP_BRANCH="stable"
               ;;
-            "experimental")
+            "experimental"|"experimental-externalUI")
               WEBAPP_BRANCH="experimental"
               ;;
             *)

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -249,6 +249,16 @@ jobs:
           echo "deploy_user=github-deploy" >> $GITHUB_ENV
           echo "deploy_server=lightinator.de" >> $GITHUB_ENV
           echo "deploy_path=/home/github-deploy/nginx/html" >> $GITHUB_ENV
+
+      - name: Port knock
+        run: |
+          if [ -n "${{ secrets.DEPLOY_KNOCK_URL }}" ]; then
+            echo "Performing port knock..."
+            curl -s "${{ secrets.DEPLOY_KNOCK_URL }}" || echo "Knock failed, continuing anyway..."
+            sleep 2
+          else
+            echo "No knock URL configured, skipping..."
+          fi
           
       - name: Add server to known_hosts
         run: |
@@ -360,15 +370,6 @@ jobs:
           EOF
           
           chmod +x staging/remote_update.sh
-          
-          # 1b. Port Knocking
-          # Explicitly allow the current runner's IP address
-          if [ -n "${{ secrets.DEPLOY_KNOCK_URL }}" ]; then
-            echo "Performing port knock..."
-            curl -s "${{ secrets.DEPLOY_KNOCK_URL }}" || echo "Knock failed, continuing anyway..."
-          else
-            echo "No knock URL configured, skipping..."
-          fi
           
           # 2. Deploy using rsync
           # -r: recursive

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,5 +1,8 @@
 name: Publish_Firmware
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_run:
     workflows: ["firmwareBuild"]

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -157,16 +157,16 @@ jobs:
           IFS=',' read -ra soc_list <<< "${{ env.supported_socs }}"
           for soc in "${soc_list[@]}"; do
             soc=$(echo "$soc" | tr -d ' ')
-            mkdir -p download/${{ env.target_branch }}/${{ env.version }}/$soc/debug
-            mkdir -p download/${{ env.target_branch }}/${{ env.version }}/$soc/release
-            mkdir -p download/${{ env.target_branch }}/${{ env.version }}/$soc/debug/single_image
-            mkdir -p download/${{ env.target_branch }}/${{ env.version }}/$soc/release/single_image
+            mkdir -p download/firmware/${{ env.target_branch }}/${{ env.version }}/$soc/debug
+            mkdir -p download/firmware/${{ env.target_branch }}/${{ env.version }}/$soc/release
+            mkdir -p download/firmware/${{ env.target_branch }}/${{ env.version }}/$soc/debug/single_image
+            mkdir -p download/firmware/${{ env.target_branch }}/${{ env.version }}/$soc/release/single_image
           done
           
           # Create version.txt file instead of symlink
-          mkdir -p download/${{ env.target_branch }}/latest
-          echo "${{ env.version }}" > download/${{ env.target_branch }}/latest/version.txt
-          echo "<html><head><meta http-equiv=\"refresh\" content=\"0; URL=../${{ env.version }}/\"></head></html>" > download/${{ env.target_branch }}/latest/index.html
+          mkdir -p download/firmware/${{ env.target_branch }}/latest
+          echo "${{ env.version }}" > download/firmware/${{ env.target_branch }}/latest/version.txt
+          echo "<html><head><meta http-equiv=\"refresh\" content=\"0; URL=../${{ env.version }}/\"></head></html>" > download/firmware/${{ env.target_branch }}/latest/index.html
           
       # Download artifacts for the current branch
       - name: Download artifacts
@@ -179,9 +179,9 @@ jobs:
             for build_type in debug release; do
               for single_img in 0 1; do
                 if [ "$single_img" = "1" ]; then
-                  path="download/${{ env.target_branch }}/${{ env.version }}/$soc/$build_type/single_image"
+                  path="download/firmware/${{ env.target_branch }}/${{ env.version }}/$soc/$build_type/single_image"
                 else
-                  path="download/${{ env.target_branch }}/${{ env.version }}/$soc/$build_type"
+                  path="download/firmware/${{ env.target_branch }}/${{ env.version }}/$soc/$build_type"
                 fi
                 combinations+=("$soc $build_type $single_img $path")
               done
@@ -304,39 +304,39 @@ jobs:
                 map_file="app.map"
               fi
               
-              url="http://$DEPLOY_SERVER/download/$TARGET_BRANCH/$VERSION/$soc/$type/$bin_file"
+              url="http://$DEPLOY_SERVER/download/firmware/$TARGET_BRANCH/$VERSION/$soc/$type/$bin_file"
               python3 manage_version.py version.json add $soc $type $TARGET_BRANCH "$VERSION" "$url" --comment-b64 "$COMMENT_B64"
               
               # ELF and map are sibling files — URL predictable by replacing bin filename.
-              echo "ELF deployed at: http://$DEPLOY_SERVER/download/$TARGET_BRANCH/$VERSION/$soc/$type/$elf_file"
-              echo "MAP deployed at: http://$DEPLOY_SERVER/download/$TARGET_BRANCH/$VERSION/$soc/$type/$map_file"
+              echo "ELF deployed at: http://$DEPLOY_SERVER/download/firmware/$TARGET_BRANCH/$VERSION/$soc/$type/$elf_file"
+              echo "MAP deployed at: http://$DEPLOY_SERVER/download/firmware/$TARGET_BRANCH/$VERSION/$soc/$type/$map_file"
             done
           done
           
           # Update 'latest' pointer
-          mkdir -p download/$TARGET_BRANCH/latest
+          mkdir -p download/firmware/$TARGET_BRANCH/latest
           # We need to make sure the target directory structure exists before writing to it
           # validation: check if the latest version directory actually exists
-          if [ -d "download/$TARGET_BRANCH/$VERSION" ]; then
-              echo "$VERSION" > download/$TARGET_BRANCH/latest/version.txt
-              echo "<html><head><meta http-equiv=\"refresh\" content=\"0; URL=../$VERSION/\"></head></html>" > download/$TARGET_BRANCH/latest/index.html
+          if [ -d "download/firmware/$TARGET_BRANCH/$VERSION" ]; then
+              echo "$VERSION" > download/firmware/$TARGET_BRANCH/latest/version.txt
+              echo "<html><head><meta http-equiv=\"refresh\" content=\"0; URL=../$VERSION/\"></head></html>" > download/firmware/$TARGET_BRANCH/latest/index.html
           else
-              echo "Warning: Version directory download/$TARGET_BRANCH/$VERSION does not exist on remote"
+              echo "Warning: Version directory download/firmware/$TARGET_BRANCH/$VERSION does not exist on remote"
           fi
 
-          # Create/update direct download symlinks: download/<soc>/<branch>/<type>/app-merged.bin
+          # Create/update direct download symlinks: download/firmware/<soc>/<branch>/<type>/app-merged.bin
           # These match the static HTML download links and always point to the latest version.
           echo "Updating direct download symlinks..."
           IFS=',' read -ra soc_list <<< "$SUPPORTED_SOCS"
           for soc in "${soc_list[@]}"; do
             soc=$(echo "$soc" | tr -d ' ')
             for type in debug release; do
-              symlink_dir="download/$soc/$TARGET_BRANCH/$type"
+              symlink_dir="download/firmware/$soc/$TARGET_BRANCH/$type"
               mkdir -p "$symlink_dir"
-              # Relative path from download/<soc>/<branch>/<type>/ up to download/ then into versioned path
-              ln -sf "../../../$TARGET_BRANCH/$VERSION/$soc/$type/single_image/app-merged.bin" \
+              # Relative path from download/firmware/<soc>/<branch>/<type>/ up to download/firmware/ then into versioned path
+              ln -sf "../../../../firmware/$TARGET_BRANCH/$VERSION/$soc/$type/single_image/app-merged.bin" \
                 "$symlink_dir/app-merged.bin"
-              echo "Symlink: $symlink_dir/app-merged.bin -> ../../../$TARGET_BRANCH/$VERSION/$soc/$type/single_image/app-merged.bin"
+              echo "Symlink: $symlink_dir/app-merged.bin -> ../../../../firmware/$TARGET_BRANCH/$VERSION/$soc/$type/single_image/app-merged.bin"
             done
           done
 
@@ -347,7 +347,7 @@ jobs:
           # Set ownership to deploy user:nginx group
           chown -R github-deploy:nginx *
           # Ensure directories are 755 and files are 644
-          find download -type d -exec chmod 755 {} \;
+          find download/firmware -type d -exec chmod 755 {} \;
           find download -type f -exec chmod 644 {} \;
           chmod +x manage_version.py
           

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -283,6 +283,10 @@ jobs:
           SUPPORTED_SOCS="${{ env.supported_socs }}"
           
           cd "$DEPLOY_PATH"
+
+          # Ensure new firmware path layout exists
+          mkdir -p "download/firmware/$TARGET_BRANCH/$VERSION"
+          mkdir -p "download/firmware/$TARGET_BRANCH/latest"
           
           echo "Updating version.json on remote..."
           

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ app-config/*
 app-data/*
 # don't include the webapp files, they need to come from the deployment
 webapp/*
+# except the static bootstrap files owned by the firmware repo
+!webapp/captive.html
+!webapp/updating.html
 include/filelist.h
 
 # exclude local script to update db that is under constant development

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,10 @@ latex
 latex/*
 
 debug_Esp32.hw
-include/fileList.h
+# fileList.h is normally downloaded from webapp CI, but for experimental
+# builds the minimal 3-entry version is committed directly in the repo.
+# The negation below allows git to track it.
+!include/fileList.h
 flashloop.sh
 colgrep
 colgrep.cfg

--- a/app-config.cfgdb
+++ b/app-config.cfgdb
@@ -52,6 +52,35 @@
         }
       }
     },
+    "webapp":{
+      "type":"object",
+      "properties":{
+        "enabled":{
+          "type":"boolean",
+          "default":true
+        },
+        "api_base_url":{
+          "type":"string",
+          "default":"http://lightinator.de/api"
+        },
+        "installed_version":{
+          "type":"string",
+          "default":""
+        },
+        "installed_md5":{
+          "type":"string",
+          "default":""
+        },
+        "last_check_status":{
+          "type":"string",
+          "default":""
+        },
+        "in_progress":{
+          "type":"boolean",
+          "default":false
+        }
+      }
+    },
     "security": {
       "type": "object",
       "properties": {

--- a/app/apihandler.cpp
+++ b/app/apihandler.cpp
@@ -127,6 +127,10 @@ bool Api::dispatchCommand(const String& method, const JsonObject& params, String
 	if(method == F("setOff") || method == F("off")) {
 		return app.jsonproc.onSetOff(params, errorMsg, relay);
 	}
+	if(method == F("keep_alive")) {
+		// No-op ping from webapp to keep the WebSocket connection alive.
+		return true;
+	}
 	if(method == F("scan_networks")) {
 		if(!app.network.isScanning()) {
 			app.network.scan(false);
@@ -350,7 +354,11 @@ bool Api::handleInfo(const JsonObject& params, JsonObject& data)
 #endif
 
 		JsonObject application = data.createNestedObject(F("app"));
-		application[F("webapp_version")] = WEBAPP_VERSION;
+		{
+			AppConfig::Root::Webapp webappCfg(*app.cfg);
+			String installedVer = webappCfg.getInstalledVersion();
+			application[F("webapp_version")] = installedVer.length() > 0 ? installedVer : String(WEBAPP_VERSION);
+		}
 		application[F("git_version")] = fw_git_version;
 		application[F("build_type")] = BUILD_TYPE;
 		application[F("git_date")] = fw_git_date;
@@ -481,7 +489,11 @@ bool Api::handleInfo(const JsonObject& params, JsonObject& data)
 	data[F("git_version")] = fw_git_version;
 	data[F("build_type")] = BUILD_TYPE;
 	data[F("git_date")] = fw_git_date;
-	data[F("webapp_version")] = WEBAPP_VERSION;
+	{
+		AppConfig::Root::Webapp webappCfg(*app.cfg);
+		String installedVer = webappCfg.getInstalledVersion();
+		data[F("webapp_version")] = installedVer.length() > 0 ? installedVer : String(WEBAPP_VERSION);
+	}
 	data[F("sming")] = SMING_VERSION;
 	data[F("event_num_clients")] = app.eventserver.activeClients;
 	data[F("uptime")] = app.getUptime();

--- a/app/application.cpp
+++ b/app/application.cpp
@@ -178,12 +178,16 @@ extern "C" void custom_crash_callback(struct rst_info* ri, uint32_t stack, uint3
 
 #endif // ARCH_ESP8266
 
-#ifndef SMING_RELEASE
-extern MultiOutputStream debugStream;
-extern size_t debugStreamOutputCallback(const char* buffer, unsigned int length);
-#endif
-
 Application app;
+
+#ifndef SMING_RELEASE
+MultiOutputStream debugStream;
+
+size_t debugStreamOutputCallback(const char* buffer, unsigned int length)
+{
+	return debugStream.write((const uint8_t*)buffer, length);
+}
+#endif
 
 void onReady()
 {
@@ -345,14 +349,7 @@ bool Application::checkHeap( size_t minHeap)
 	}
 	return true;
 }
-#ifndef SMING_RELEASE
-MultiOutputStream debugStream;
 
-size_t debugStreamOutputCallback(const char* buffer, unsigned int length)
-{
-	return debugStream.write((const uint8_t*)buffer, length);
-}
-#endif
 void Application::init()
 {
 	debug_i("ESP RGBWW Controller Version %s\r\n", fw_git_version);

--- a/app/networking.cpp
+++ b/app/networking.cpp
@@ -376,6 +376,9 @@ void AppWIFI::_STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway)
 #ifndef SMING_RELEASE
 	app.udpSyslogStream.drainPreNetBuffer();
 #endif
+
+	// Kick off background webapp update check now that we have a routable IP.
+	app.webappOta.checkForUpdate();
 }
 
 /**
@@ -398,6 +401,16 @@ void AppWIFI::stopAp(int delay)
 	debug_i("AppWIFI::stopAp");
 	debug_i("Disabling AP");
 	_timer.stop();
+
+	// Don't shut down the AP while the webapp is still downloading — the user's
+	// browser may be connected via the AP to watch the updating page.  Poll every
+	// 10 s until the download is done, then disable the AP.
+	if(app.webappOta.isActive()) {
+		debug_i("AppWIFI::stopAp - webapp OTA in progress, deferring AP stop by 10s");
+		_timer.initializeMs(10000, std::bind(&AppWIFI::stopAp, this, 0)).startOnce();
+		return;
+	}
+
 	if(WifiAccessPoint.isEnabled()) {
 		debug_i("AppWIFI::stopAp WifiAP disable");
 		WifiAccessPoint.enable(false, false);

--- a/app/otaupdate.cpp
+++ b/app/otaupdate.cpp
@@ -184,7 +184,7 @@ void ApplicationOTA::start(String romurl)
 	 * ############################################################
 	 * ##### HIGH RISK: CORE OTA TRANSACTION SETUP            #####
 	 * ##### Changes here can brick OTA-only recoverable      #####
-	 * ##### devices.                                          #####
+	 * ##### devices.                                         #####
 	 * ############################################################
 	 */
 	debug_i("ApplicationOTA::start");
@@ -665,6 +665,8 @@ std::vector<Storage::esp_partition_info_t> ApplicationOTA::getEditablePartitionT
 	for(auto partition : table) {
 		Storage::esp_partition_info_t entry;
 		entry.magic = 0x50AA;
+		// TODO(#138): strncpy does not guarantee null-termination if name is exactly sizeof(entry.name) bytes.
+		// Fix: use sizeof(entry.name)-1 and set entry.name[sizeof(entry.name)-1] = '\0'.
 		strncpy(entry.name, partition.name().c_str(), sizeof(entry.name));
 		entry.type = partition.type();
 		entry.subtype = partition.subType();
@@ -692,9 +694,9 @@ bool ApplicationOTA::addPartition(std::vector<Storage::esp_partition_info_t>& pa
 {
 	Storage::esp_partition_info_t newPartition;
 	newPartition.magic = 0x50AA;
+	// TODO(#138): strncpy does not guarantee null-termination — see same issue in getEditablePartitionTable.
 	strncpy(newPartition.name, name.c_str(), sizeof(newPartition.name));
 	newPartition.type = static_cast<Storage::Partition::Type>(type);
-	//newPartition.subtype=static_cast<Storage::Partition::subtype>(subType);
 	newPartition.subtype = subType;
 	newPartition.offset = start;
 	newPartition.size = size;
@@ -729,6 +731,13 @@ bool ApplicationOTA::savePartitionTable(std::vector<Storage::esp_partition_info_
 	std::sort(partitionTable.begin(), partitionTable.end(),
 			  [](const auto& a, const auto& b) { return a.offset < b.offset; });
 
+	// TODO(#136): overlap check condition is inverted — checks (B.offset + B.size) < A.end
+	// instead of (B.offset < A.end).  A partition that starts inside A but extends past it
+	// will not be detected.  Fix: replace the condition with `partition.offset < partitionEnd`.
+	// TODO(#137): no upper-bound check — a partition whose end exceeds the flash size
+	// (hardcoded 0x400000) is silently accepted.  Fix: add
+	//   if (partition.offset + partition.size > FLASH_SIZE) return false;
+	// before the overlap test.
 	// Check for overlaps
 	bool isFirst = true;
 	uint32_t partitionEnd;
@@ -736,7 +745,7 @@ bool ApplicationOTA::savePartitionTable(std::vector<Storage::esp_partition_info_
 		Serial << "Partition: " << partition.name << " start: " << partition.offset
 			   << " end: " << partition.offset + partition.size << endl;
 		if(!isFirst) {
-			if((partition.offset + partition.size) < partitionEnd) {
+			if((partition.offset + partition.size) < partitionEnd) { // TODO(#136): condition is inverted, see above
 				// Overlap detected, handle error
 				Serial << "Error: Overlapping partitions detected " << partition.name << endl;
 				return false;
@@ -769,6 +778,7 @@ bool ApplicationOTA::savePartitionTable(std::vector<Storage::esp_partition_info_
 		// Add the partition entry
 		Storage::esp_partition_info_t entry;
 		entry.magic = 0x50AA;
+		// TODO(#138): strncpy does not guarantee null-termination — see same issue in getEditablePartitionTable.
 		strncpy(entry.name, partition.name, sizeof(entry.name));
 		entry.type = partition.type;
 		entry.subtype = partition.subtype;

--- a/app/telemetry.cpp
+++ b/app/telemetry.cpp
@@ -101,10 +101,17 @@ void TelemetryClient::connect(const String& telemetryURL, const String& telemetr
 }
 
 void TelemetryClient::reconnect() {
+    // Schedule the actual stop+connect from the top of the event loop via a
+    // 1-second timer.  Calling stop() (which deletes the MqttClient) and then
+    // delay(1000) here would yield the event loop while stale TCP callbacks
+    // still reference the deleted object → use-after-free crash.
+    _reconnectTimer.initializeMs<1000>(TimerDelegate(&TelemetryClient::doReconnect, this)).startOnce();
+}
+
+void TelemetryClient::doReconnect() {
     stop();
-    delay(1000); // brief delay before reconnecting
     connect(_telemetryURL, _telemetryUser, _telemetryPass);
- }
+}
 
 void TelemetryClient::onComplete(TcpClient& client, bool success) {
 	if (!success) {

--- a/app/webappota.cpp
+++ b/app/webappota.cpp
@@ -1,0 +1,632 @@
+/**
+ * @file
+ * @author  Peter Jakobs http://github.com/pljakobs
+ *
+ * Background webapp OTA — fetch webapp files from lightinator.de version API,
+ * stage in LittleFS, verify MD5, then atomically activate.
+ *
+ * See include/webappota.h for the full design description.
+ */
+
+#include <webappota.h>
+#include <application.h>
+#include <ArduinoJson.h>
+#include <FileSystem.h>
+#include <Crypto/Md5.h>
+#include <Data/HexString.h>
+#include <Data/Stream/FileStream.h>
+#include <vector>
+
+/*
+ * File-system layout:
+ *   staging/<path>   — files being downloaded / just verified
+ *   <path>           — active files served by the webserver
+ */
+static constexpr const char STAGING_ROOT[] = "staging";
+
+// Retry interval on transient failures (ms)
+static constexpr uint32_t RETRY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+String WebappOta::stagingPath(const String& relPath)
+{
+    return String(STAGING_ROOT) + "/" + relPath;
+}
+
+/**
+ * @brief Create all parent directories for @p path if they don't exist.
+ * @param path  e.g. "staging/assets/index.js.gz"
+ * @retval true on success or if no parent dir needed
+ */
+bool WebappOta::ensureParentDir(const String& path)
+{
+    int sep = path.lastIndexOf('/');
+    if(sep <= 0) {
+        return true; // root level, no parent needed
+    }
+    String dir = path.substring(0, sep);
+    // createDirectories (makedirs) only creates intermediate components, not
+    // the final directory itself (stops before the last non-slash segment).
+    // Call it first for any intermediate dirs, then mkdir the final dir.
+    int res = createDirectories(dir);
+    if(res < 0 && res != IFS::Error::Exists) {
+        debug_e("WebappOta::ensureParentDir - makedirs('%s') = %d", dir.c_str(), res);
+        return false;
+    }
+    res = createDirectory(dir);
+    if(res < 0 && res != IFS::Error::Exists) {
+        debug_e("WebappOta::ensureParentDir - mkdir('%s') = %d", dir.c_str(), res);
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @brief Extract the branch segment from a firmware version string.
+ *
+ * CI format:   "V5.0-599-testing"              → "testing"
+ * Local format: "V5.0-847-experimental-extra"  → "experimental"
+ *
+ * Splits on '-', skips segment 0 (e.g. "V5.0") and segment 1 if numeric
+ * (build number), returns segment 2 as the branch name.
+ * Falls back to "experimental" if the version string doesn't match.
+ */
+String WebappOta::extractBranch(const String& firmwareVersion)
+{
+    // Find the third hyphen-separated token
+    int firstDash = firmwareVersion.indexOf('-');
+    if(firstDash < 0) {
+        return F("experimental");
+    }
+    int secondDash = firmwareVersion.indexOf('-', firstDash + 1);
+    if(secondDash < 0) {
+        return F("experimental");
+    }
+    int thirdDash = firmwareVersion.indexOf('-', secondDash + 1);
+    String branch = (thirdDash > 0)
+        ? firmwareVersion.substring(secondDash + 1, thirdDash)
+        : firmwareVersion.substring(secondDash + 1);
+    return branch.length() > 0 ? branch : F("experimental");
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+bool WebappOta::wasInterrupted() const
+{
+    AppConfig::Root::Webapp webapp(*app.cfg);
+    return webapp.getInProgress();
+}
+
+void WebappOta::checkForUpdate()
+{
+    if(_state != State::IDLE) {
+        debug_i("WebappOta::checkForUpdate - already active, skipping");
+        return;
+    }
+
+    AppConfig::Root::Webapp webapp(*app.cfg);
+    if(!webapp.getEnabled()) {
+        debug_i("WebappOta::checkForUpdate - disabled in config");
+        return;
+    }
+
+    if(webapp.getInProgress()) {
+        debug_i("WebappOta::checkForUpdate - resuming interrupted download");
+    }
+
+    String apiBaseUrl = webapp.getApiBaseUrl();
+    String branch = extractBranch(fw_git_version);
+
+    debug_i("WebappOta::checkForUpdate - branch=%s fw=%s", branch.c_str(), fw_git_version);
+    queryApi(branch, fw_git_version, apiBaseUrl);
+}
+
+// ─── API query ───────────────────────────────────────────────────────────────
+
+void WebappOta::queryApi(const String& branch, const String& firmwareVersion, const String& apiBaseUrl)
+{
+    _state = State::QUERYING_API;
+    broadcastStatus();
+    _files.clear();
+    _fileIndex = 0;
+
+    String url = apiBaseUrl + F("/webapp/latest?branch=") + branch
+               + F("&firmware_version=") + firmwareVersion;
+
+    debug_i("WebappOta::queryApi - GET %s", url.c_str());
+
+    if(!_httpClient.downloadString(url,
+            RequestCompletedDelegate(&WebappOta::onApiResponse, this), 4096)) {
+        debug_e("WebappOta::queryApi - failed to queue request");
+        _state = State::IDLE;
+        saveState("", "", "api_error");
+    }
+}
+
+int WebappOta::onApiResponse(HttpConnection& client, bool successful)
+{
+    auto* response = client.getResponse();
+    if(!response) {
+        debug_e("WebappOta::onApiResponse - no response object");
+        _state = State::IDLE;
+        saveState("", "", "api_error");
+        return 0;
+    }
+
+    int code = (int)response->code;
+
+    if(!successful || (code != 200 && code != 0 /* 0 = no code set */)) {
+        debug_i("WebappOta::onApiResponse - HTTP %d, no update available", code);
+        _state = State::IDLE;
+        saveState("", "", (code == 404) ? "no_update" : "api_error");
+        return 0;
+    }
+
+    String body = response->getBody();
+    if(body.length() == 0) {
+        debug_e("WebappOta::onApiResponse - empty body");
+        _state = State::IDLE;
+        saveState("", "", "api_error");
+        return 0;
+    }
+
+    debug_d("WebappOta::onApiResponse - body: %s", body.c_str());
+
+    // Parse JSON — the /webapp/latest endpoint with a fixed branch returns a
+    // single version object (not an array).
+    // Expected shape:
+    //   { "version": "5.2.0", "branch": "testing", "files": [
+    //       { "path": "index.html.gz", "md5": "abc123" },
+    //       ...
+    //   ] }
+    // Response is ~1 KB raw JSON; ArduinoJson needs ~2-3x that internally.
+    // Use DynamicJsonDocument on the heap to avoid stack overflow on ESP8266.
+    DynamicJsonDocument doc(3072);
+    DeserializationError err = deserializeJson(doc, body);
+    if(err) {
+        debug_e("WebappOta::onApiResponse - JSON parse error: %s", err.c_str());
+        _state = State::IDLE;
+        saveState("", "", "api_error");
+        return 0;
+    }
+
+    const char* version = doc["version"];
+    if(version == nullptr) {
+        debug_e("WebappOta::onApiResponse - missing 'version' field");
+        _state = State::IDLE;
+        saveState("", "", "api_error");
+        return 0;
+    }
+    _pendingVersion = version;
+
+    // Compare against installed version
+    {
+        AppConfig::Root::Webapp webapp(*app.cfg);
+        if(webapp.getInstalledVersion() == _pendingVersion) {
+            debug_i("WebappOta::onApiResponse - already up to date (%s)", _pendingVersion.c_str());
+            _state = State::IDLE;
+            saveState(_pendingVersion, webapp.getInstalledMd5(), "no_update");
+            return 0;
+        }
+    }
+
+    // Populate file list
+    JsonArray files = doc["files"];
+    if(files.isNull() || files.size() == 0) {
+        debug_e("WebappOta::onApiResponse - no files in response");
+        _state = State::IDLE;
+        saveState("", "", "api_error");
+        return 0;
+    }
+
+    const char* basepath = doc["basepath"];
+    if(basepath == nullptr) {
+        debug_e("WebappOta::onApiResponse - missing basepath in response");
+        _state = State::IDLE;
+        saveState("", "", "api_error");
+        return 0;
+    }
+    String base(basepath);
+
+    for(JsonObject f : files) {
+        const char* filename = f["filename"];
+        const char* md5      = f["md5"];
+        if(filename == nullptr || md5 == nullptr) {
+            debug_e("WebappOta::onApiResponse - file entry missing filename/md5, skipping version");
+        _state = State::IDLE;
+            saveState("", "", "api_error");
+            return 0;
+        }
+        FileEntry entry;
+        entry.path        = filename;
+        entry.expectedMd5 = md5;
+        entry.url         = base + filename;
+        _files.push_back(entry);
+    }
+
+    debug_i("WebappOta::onApiResponse - will download %d files for version %s",
+            (int)_files.size(), _pendingVersion.c_str());
+
+    _totalFiles = (unsigned)_files.size();
+
+    // Resume support: if staging already has a correctly-verified file from a
+    // previous (interrupted) download attempt, skip re-downloading it.
+    {
+        std::vector<FileEntry> pending;
+        for(auto& f : _files) {
+            String sp = stagingPath(f.path);
+            if(fileExist(sp) && verifyFileMd5(sp, f.expectedMd5)) {
+                debug_i("WebappOta::onApiResponse - resume: skipping already-verified %s", f.path.c_str());
+            } else {
+                pending.push_back(std::move(f));
+            }
+        }
+        _files = std::move(pending);
+    }
+
+    if(_files.empty()) {
+        // All files already staged and verified — go straight to activation.
+        debug_i("WebappOta::onApiResponse - all files already staged, activating");
+        _state = State::ACTIVATING;
+        _fileIndex = 0;
+        broadcastStatus();
+        _retryTimer.initializeMs<1>(TimerDelegate(&WebappOta::activateStagingDeferred, this));
+        _retryTimer.startOnce();
+        return 0;
+    }
+
+    debug_i("WebappOta::onApiResponse - %u files to download (%u already staged)",
+            (unsigned)_files.size(), _totalFiles - (unsigned)_files.size());
+
+    // Mark download as in-progress in persistent config so a reboot can resume.
+    {
+        AppConfig::Root root(*app.cfg);
+        if(auto update = root.update()) {
+            update.webapp.setInProgress(true);
+        }
+    }
+
+    _state = State::DOWNLOADING;
+    _fileIndex = 0;
+    broadcastStatus();
+    // Defer startNextDownload out of the HTTP callback context.
+    // Calling downloadFile() from inside onMessageComplete (via
+    // requestCompletedDelegate) re-enters the HttpClientConnection state
+    // machine before it has finished cleaning up the current request, which
+    // can cause a hang/WDT reset.  A 1 ms timer breaks us out of that context.
+    _retryTimer.initializeMs<1>(TimerDelegate(&WebappOta::startNextDownload, this));
+    _retryTimer.startOnce();
+    return 0;
+}
+
+// ─── File download ────────────────────────────────────────────────────────────
+
+void WebappOta::startNextDownload()
+{
+    if(_fileIndex >= (unsigned)_files.size()) {
+        // All files downloaded; move to activation
+        _state = State::ACTIVATING;
+        broadcastStatus();
+        if(!activateStaging()) {
+            cleanupStaging();
+            _state = State::IDLE;
+            saveState("", "", "activation_error");
+        }
+        return;
+    }
+
+    // Require at least 16 KB free heap before starting a download.
+    // The HttpClient + lwIP TCP buffers + FileStream need headroom.
+    // Back off for 30 s and retry — the system may free heap after GC.
+    static constexpr size_t MIN_DOWNLOAD_HEAP = 12000;
+    if(app.getFreeHeapSize() < MIN_DOWNLOAD_HEAP) {
+        debug_w("WebappOta::startNextDownload - low heap (%u), backing off 30s",
+                app.getFreeHeapSize());
+        saveState("", "", "low_heap");
+        // Don't broadcastStatus here — we already checked heap is low and broadcastStatus
+        // itself allocates.  The updating page will get the next push when download resumes.
+        _retryTimer.initializeMs(30000, TimerDelegate(&WebappOta::startNextDownload, this));
+        _retryTimer.startOnce();
+        return;
+    }
+
+    const FileEntry& entry = _files[_fileIndex];
+    String destPath = stagingPath(entry.path);
+
+    if(!ensureParentDir(destPath)) {
+        debug_e("WebappOta::startNextDownload - makedirs failed for %s", destPath.c_str());
+        cleanupStaging();
+        _state = State::IDLE;
+        saveState("", "", "download_error");
+        return;
+    }
+
+    debug_i("WebappOta::startNextDownload - [%u/%u] %s → %s",
+            _fileIndex + 1, (unsigned)_files.size(), entry.url.c_str(), destPath.c_str());
+    broadcastStatus();
+
+    if(!_httpClient.downloadFile(entry.url, destPath,
+            RequestCompletedDelegate(&WebappOta::onFileDownloaded, this))) {
+        debug_e("WebappOta::startNextDownload - failed to queue download");
+        cleanupStaging();
+        _state = State::IDLE;
+        saveState("", "", "download_error");
+    }
+}
+
+int WebappOta::onFileDownloaded(HttpConnection& client, bool successful)
+{
+    auto* response = client.getResponse();
+    int code = response ? (int)response->code : 0;
+
+    if(!successful || (code != 200 && code != 0)) {
+        const FileEntry& entry = _files[_fileIndex];
+        String destPath = stagingPath(entry.path);
+        debug_e("WebappOta::onFileDownloaded - HTTP %d for %s", code, destPath.c_str());
+        cleanupStaging();
+        _state = State::IDLE;
+        saveState("", "", "download_error");
+        return 0;
+    }
+
+    // Defer MD5 verification to the next event-loop tick.
+    // The HttpClientConnection destroys the FileStream (response buffer) after
+    // the callback returns, which is when the file is actually flushed and
+    // closed on LittleFS.  Reading the file inside this callback would see an
+    // empty or partial file.  A 1 ms one-shot timer defers execution until
+    // after the connection cleanup completes.
+    _retryTimer.initializeMs<1>(TimerDelegate(&WebappOta::verifyAndContinue, this));
+    _retryTimer.startOnce();
+
+    return 0;
+}
+
+void WebappOta::verifyAndContinue()
+{
+    const FileEntry& entry = _files[_fileIndex];
+    String destPath = stagingPath(entry.path);
+
+    if(!verifyFileMd5(destPath, entry.expectedMd5)) {
+        debug_e("WebappOta::verifyAndContinue - MD5 mismatch for %s", destPath.c_str());
+        cleanupStaging();
+        _state = State::IDLE;
+        saveState("", "", "md5_error");
+        return;
+    }
+
+    debug_i("WebappOta::verifyAndContinue - [%u/%u] OK: %s",
+            _fileIndex + 1, (unsigned)_files.size(), destPath.c_str());
+
+    ++_fileIndex;
+    broadcastStatus();
+    startNextDownload();
+}
+
+// ─── MD5 verification ────────────────────────────────────────────────────────
+
+bool WebappOta::verifyFileMd5(const String& filePath, const String& expectedMd5)
+{
+    FileStream fs;
+    if(!fs.open(filePath, File::ReadOnly)) {
+        debug_e("WebappOta::verifyFileMd5 - cannot open %s", filePath.c_str());
+        return false;
+    }
+
+    Crypto::Md5 md5;
+    uint8_t buf[256];
+    while(true) {
+        int n = fs.readBytes(reinterpret_cast<char*>(buf), sizeof(buf));
+        if(n <= 0) break;
+        md5.update(buf, n);
+    }
+    fs.close();
+
+    String computed = Crypto::toString(md5.getHash());
+    computed.toLowerCase();
+
+    bool match = (computed == expectedMd5);
+    if(!match) {
+        debug_e("WebappOta::verifyFileMd5 - expected %s got %s for %s",
+                expectedMd5.c_str(), computed.c_str(), filePath.c_str());
+    }
+    return match;
+}
+
+// ─── Activation ──────────────────────────────────────────────────────────────
+
+/**
+ * @brief Recursively move all files from @p srcDir to @p dstDir.
+ *
+ * For each file found in @p srcDir (recursively), the corresponding file in
+ * @p dstDir is deleted (if present) and the staged file is renamed into place.
+ * The source file's parent path relative to @p srcDir is re-created under
+ * @p dstDir as needed.
+ *
+ * @note LittleFS rename() supports moving a file across directories as long
+ *       as the destination parent directory exists.
+ */
+bool WebappOta::moveTree(const String& srcDir, const String& dstDir)
+{
+    Directory dir;
+    if(!dir.open(srcDir)) {
+        debug_e("WebappOta::moveTree - cannot open %s", srcDir.c_str());
+        return false;
+    }
+
+    bool ok = true;
+    while(dir.next()) {
+        auto& stat = dir.stat();
+        String name = stat.name.c_str();
+        String src = srcDir + "/" + name;
+        String dst = dstDir + "/" + name;
+
+        if(stat.attr[FileAttribute::Directory]) {
+            if(!ensureParentDir(dst + "/_")) { // ensure dstDir/<subdir> exists
+                createDirectories(dst);
+            }
+            if(!moveTree(src, dst)) {
+                ok = false;
+            }
+        } else {
+            // Delete destination file if it exists (ignore errors)
+            if(fileExist(dst)) {
+                fileDelete(dst);
+            }
+            if(!ensureParentDir(dst)) {
+                debug_e("WebappOta::moveTree - makedirs failed for %s", dst.c_str());
+                ok = false;
+                continue;
+            }
+            int res = fileRename(src, dst);
+            if(res < 0) {
+                debug_e("WebappOta::moveTree - rename %s → %s failed (%d)", src.c_str(), dst.c_str(), res);
+                ok = false;
+            } else {
+                debug_d("WebappOta::moveTree - %s → %s", src.c_str(), dst.c_str());
+            }
+        }
+    }
+    return ok;
+}
+
+void WebappOta::activateStagingDeferred()
+{
+    if(!activateStaging()) {
+        cleanupStaging();
+        _state = State::IDLE;
+        saveState("", "", "activation_error");
+    }
+}
+
+bool WebappOta::activateStaging()
+{
+    debug_i("WebappOta::activateStaging - activating version %s", _pendingVersion.c_str());
+
+    // Move staged files to the filesystem root (where the webserver serves from)
+    if(!moveTree(STAGING_ROOT, "")) {
+        debug_e("WebappOta::activateStaging - moveTree failed");
+        return false;
+    }
+
+    // Cleanup empty staging directories
+    cleanupStaging();
+
+    // Use the last file's MD5 as the overall bundle fingerprint for now
+    String bundleMd5;
+    if(_files.size() > 0) {
+        bundleMd5 = _files[_files.size() - 1].expectedMd5;
+    }
+
+    _state = State::IDLE;
+    saveState(_pendingVersion, bundleMd5, "ok");
+
+    debug_i("WebappOta::activateStaging - webapp updated to %s", _pendingVersion.c_str());
+    app.wsBroadcast(F("notification"),
+                    F("Webapp updated to ") + _pendingVersion);
+
+    // Reboot to reclaim heap used during download before serving the webapp.
+    // The updating.html page polls /webapp_status; when it sees last_status=="ok"
+    // it reloads — the reload will land on a freshly booted device.
+    debug_i("WebappOta::activateStaging - rebooting to reclaim heap");
+    System.restart(2000); // 2 s grace period for the status response to reach the browser
+
+    return true;
+}
+
+// ─── Persistence ─────────────────────────────────────────────────────────────
+
+void WebappOta::saveState(const String& version, const String& md5, const String& status)
+{
+    AppConfig::Root root(*app.cfg);
+    if(auto update = root.update()) {
+        if(version.length() > 0) {
+            update.webapp.setInstalledVersion(version);
+        }
+        if(md5.length() > 0) {
+            update.webapp.setInstalledMd5(md5);
+        }
+        update.webapp.setLastCheckStatus(status);
+        // Clear in_progress whenever we reach a terminal state.
+        // It is set to true by checkForUpdate() when a download begins.
+        if(status == "ok" || status == "no_update" || status == "api_error" ||
+           status == "download_error" || status == "md5_error" || status == "activation_error") {
+            update.webapp.setInProgress(false);
+        }
+    }
+    debug_d("WebappOta::saveState - version=%s md5=%s status=%s",
+            version.c_str(), md5.c_str(), status.c_str());
+    // Push updated state to all websocket clients so the updating page
+    // reacts immediately without waiting for the next HTTP poll.
+    // Skip for transient backoff states where heap is already known to be low.
+    if(status != "low_heap") {
+        broadcastStatus();
+    }
+}
+
+void WebappOta::cleanupStaging()
+{
+    // Best-effort recursive delete of staging directory contents.
+    // Errors are non-fatal; leftover staging files don't affect correctness
+    // because they are only activated by an explicit activateStaging() call.
+    Directory dir;
+    if(!dir.open(STAGING_ROOT)) {
+        return;
+    }
+    std::vector<String> entries;
+    while(dir.next()) {
+        entries.push_back(String(STAGING_ROOT) + "/" + dir.stat().name.c_str());
+    }
+    dir.close();
+
+    for(unsigned i = 0; i < entries.size(); ++i) {
+        fileDelete(entries[i]);
+    }
+}
+
+// ─── Status JSON ─────────────────────────────────────────────────────────────
+
+void WebappOta::fillStatusJson(JsonObject& obj) const
+{
+    static const char* stateNames[] = {
+        "idle",         // IDLE
+        "querying_api", // QUERYING_API
+        "downloading",  // DOWNLOADING
+        "activating",   // ACTIVATING
+    };
+    obj[F("state")] = stateNames[static_cast<int>(_state)];
+    // "file" = number of files fully processed (skipped + downloaded so far)
+    unsigned done = (_totalFiles > (unsigned)_files.size())
+                    ? _totalFiles - (unsigned)_files.size()
+                    : 0;
+    obj[F("file")]  = (int)(done + _fileIndex);
+    obj[F("total")] = (int)(_totalFiles > 0 ? _totalFiles : _files.size());
+
+    if(_state == State::DOWNLOADING && _fileIndex < (unsigned)_files.size()) {
+        obj[F("file_path")] = _files[_fileIndex].path;
+    }
+    if(_pendingVersion.length() > 0) {
+        obj[F("version")] = _pendingVersion;
+    }
+
+    // Read persisted fields from ConfigDB
+    AppConfig::Root::Webapp webapp(*app.cfg);
+    obj[F("last_status")] = webapp.getLastCheckStatus();
+    obj[F("in_progress")] = webapp.getInProgress();
+}
+
+void WebappOta::broadcastStatus() const
+{
+    // Don't broadcast if heap is too tight — wsBroadcast allocates a JsonRpcMessage,
+    // a serialised String, and a char[] frame buffer.  Attempting this in a low-heap
+    // situation (the very condition we're trying to report) can itself crash the device.
+    static constexpr size_t MIN_BROADCAST_HEAP = 10240;
+    if(app.getFreeHeapSize() < MIN_BROADCAST_HEAP) {
+        debug_w("WebappOta::broadcastStatus - skipping, low heap (%u)", app.getFreeHeapSize());
+        return;
+    }
+    StaticJsonDocument<256> doc;
+    JsonObject params = doc.to<JsonObject>();
+    fillStatusJson(params);
+    app.wsBroadcast(F("webapp_ota_status"), params);
+}

--- a/app/webserver.cpp
+++ b/app/webserver.cpp
@@ -134,6 +134,7 @@ void ApplicationWebserver::init()
 	paths.set(F("/color"), HttpPathDelegate(&ApplicationWebserver::onColor, this));
 	paths.set(F("/networks"), HttpPathDelegate(&ApplicationWebserver::onNetworks, this));
 	paths.set(F("/scan_networks"), HttpPathDelegate(&ApplicationWebserver::onScanNetworks, this));
+	paths.set(F("/webapp_status"), HttpPathDelegate(&ApplicationWebserver::onWebappStatus, this));
 	paths.set(F("/system"), HttpPathDelegate(&ApplicationWebserver::onSystemReq, this));
 	paths.set(F("/update"), HttpPathDelegate(&ApplicationWebserver::onUpdate, this));
 	paths.set(F("/connect"), HttpPathDelegate(&ApplicationWebserver::onConnect, this));
@@ -178,6 +179,19 @@ void ApplicationWebserver::wsConnected(WebsocketConnection& socket)
 	debug_i("===>wsConnected");
 	webSockets.addElement(&socket);
 	debug_i("===>nr of websockets: %i", webSockets.size());
+
+	// If a webapp OTA is in progress, push the current state immediately so
+	// the updating page doesn't have to wait for the next timed broadcast.
+	if(app.webappOta.isActive()) {
+		StaticJsonDocument<256> doc;
+		JsonObject params = doc.to<JsonObject>();
+		app.webappOta.fillStatusJson(params);
+		JsonRpcMessage msg(F("webapp_ota_status"));
+		msg.setId(0);
+		JsonObject root = msg.getParams();
+		for(JsonPair kv : params) root[kv.key()] = kv.value();
+		socket.sendString(Json::serialize(msg.getRoot()));
+	}
 }
 
 void ApplicationWebserver::wsDisconnected(WebsocketConnection& socket)
@@ -281,8 +295,11 @@ bool ICACHE_FLASH_ATTR ApplicationWebserver::authenticateExec(HttpRequest& reque
 {
 	{
 		debug_i("ApplicationWebserver::authenticated - checking general context");
-		AppConfig::Root config(*app.cfg);
-		if(!config.security.getApiSecured())
+		if(_apiSecuredCache < 0) {
+			AppConfig::Root config(*app.cfg);
+			_apiSecuredCache = config.security.getApiSecured() ? 1 : 0;
+		}
+		if(_apiSecuredCache == 0)
 			return true;
 	} // end AppConfig general context
 
@@ -387,7 +404,11 @@ void ApplicationWebserver::addInfoFields(JsonObject& obj)
 	dev[F("current_rom")] = String(app.ota.getRomPartition().name());
 #endif
 	JsonObject application = obj.createNestedObject(F("app"));
-	application[F("webapp_version")] = WEBAPP_VERSION;
+	{
+		AppConfig::Root::Webapp webappCfg(*app.cfg);
+		String installedVer = webappCfg.getInstalledVersion();
+		application[F("webapp_version")] = installedVer.length() > 0 ? installedVer : String(WEBAPP_VERSION);
+	}
 	application[F("git_version")] = fw_git_version;
 	application[F("build_type")] = BUILD_TYPE;
 	application[F("git_date")] = fw_git_date;
@@ -450,7 +471,8 @@ bool ApplicationWebserver::parseJsonBody(HttpRequest& request, HttpResponse& res
 void ApplicationWebserver::onFile(HttpRequest& request, HttpResponse& response)
 {
 	debug_i("http onFile");
-	if(!preflightRequest(request, response, {HttpMethod::GET, HttpMethod::HEAD})) return;
+	// LittleFS file serving buffers through lwIP — require more free heap than API calls.
+	if(!preflightRequest(request, response, {HttpMethod::GET, HttpMethod::HEAD}, 10000)) return;
 
 #ifdef ARCH_ESP8266
 	if(app.ota.isProccessing()) {
@@ -501,8 +523,9 @@ void ApplicationWebserver::onFile(HttpRequest& request, HttpResponse& response)
 				//response.setCache(604800, true); // It's important to use cache for better performance.
 				response.setHeader(F("Cache-Control"),F("public, max-age=604800, immutable"));
 #endif
-				response.code = HTTP_STATUS_OK;
-				response.sendFile(fileName);
+				// sendFile with allowGzipFileCheck=true: tries fileName+".gz" first, sets
+				// Content-Encoding:gzip, and infers MIME from fileName (not fileName.gz).
+				response.sendFile(fileName, true);
 			}
 			return;
 		}
@@ -539,11 +562,68 @@ void ApplicationWebserver::onIndex(HttpRequest& request, HttpResponse& response)
 	}
 #endif
 
+	bool hasLfsIndex = app.isFilesystemMounted() &&
+	                   (fileExist(F("index.html")) || fileExist(F("index.html.gz")));
+
+	// Case 1: AP active with no WiFi credentials → serve captive portal
+	if(WifiAccessPoint.isEnabled() && !WifiStation.isConnected() && !hasLfsIndex) {
+		debug_i("onIndex: serving captive portal");
+		auto v = fileMap[F("captive.html")];
+		if(v) {
+			setCorsHeaders(response);
+			response.headers[HTTP_HEADER_CACHE_CONTROL] = F("no-store");
+			auto stream = std::make_unique<FSTR::Stream>(v.content());
+			response.sendDataStream(stream.release(), MIME_HTML);
+			return;
+		}
+	}
+
+	// Case 2: WiFi connected but webapp not yet in LFS → show progress page
+	if(WifiStation.isConnected() && !hasLfsIndex) {
+		debug_i("onIndex: serving updating page");
+		// Kick off webapp OTA if not already running
+		if(!app.webappOta.isActive()) {
+			app.webappOta.checkForUpdate();
+		}
+		auto v = fileMap[F("updating.html")];
+		if(v) {
+			setCorsHeaders(response);
+			// Must not be cached — the page content changes with firmware and its
+			// poll interval is baked in. Heuristic caching would serve a stale copy.
+			response.headers[HTTP_HEADER_CACHE_CONTROL] = F("no-store");
+			auto stream = std::make_unique<FSTR::Stream>(v.content());
+			response.sendDataStream(stream.release(), MIME_HTML);
+			return;
+		}
+	}
+
+	// Normal: LFS webapp is present, redirect to index.html
 	response.headers[HTTP_HEADER_LOCATION] = F("/index.html");
 	setCorsHeaders(response);
-
 	response.code = HTTP_STATUS_PERMANENT_REDIRECT;
 	response.sendString(F("Redirecting to /index.html"));
+}
+
+void ApplicationWebserver::onWebappStatus(HttpRequest& request, HttpResponse& response)
+{
+	debug_i("http onWebappStatus");
+	if(!preflightRequest(request, response, {HttpMethod::GET}, 12000)) return;
+
+	unsigned long now = millis();
+	// Bypass cache when OTA is idle (terminal state) so updating.html sees the final result immediately.
+	bool otaActive = app.webappOta.isActive();
+	if(_webappStatusCache.length() == 0 || !otaActive || (now - _webappStatusCacheTime) >= WEBAPP_STATUS_CACHE_MS) {
+		DynamicJsonDocument doc(512);
+		JsonObject json = doc.to<JsonObject>();
+		app.webappOta.fillStatusJson(json);
+		_webappStatusCache = String();
+		serializeJson(doc, _webappStatusCache);
+		_webappStatusCacheTime = now;
+	}
+
+	setCorsHeaders(response);
+	response.headers[HTTP_HEADER_CONTENT_TYPE] = F("application/json");
+	response.sendString(_webappStatusCache);
 }
 
 bool ApplicationWebserver::checkHeap(HttpResponse& response)
@@ -553,11 +633,14 @@ bool ApplicationWebserver::checkHeap(HttpResponse& response)
 
 bool ApplicationWebserver::checkHeap(HttpResponse& response, int minHeap)
 {
-
 	if(!app.checkHeap(minHeap) ) {
 		setCorsHeaders(response);
 		response.code = HTTP_STATUS_TOO_MANY_REQUESTS;
-		response.setHeader(F("Retry-After"), "4");
+		// If webapp OTA is active the heap stays low for ~30 s (download backoff).
+		// Tell the browser to wait that long so it doesn't hammer us with retries
+		// that each cost a TCP connection + lwIP buffers.
+		int retryAfter = app.webappOta.isActive() ? 30 : 4;
+		response.setHeader(F("Retry-After"), String(retryAfter));
 		debug_e("Not enough heap free, rejecting request. Free heap: %u", app.getFreeHeapSize());
 		return false;
 	}
@@ -650,6 +733,8 @@ void ApplicationWebserver::onConfig(HttpRequest& request, HttpResponse& response
 	if(request.method == HttpMethod::POST) {
 		debug_i("======================\nHTTP POST request received, ");
 		app.telemetryClient.log(F("onConfig POST"));
+		// Invalidate the cached security flag so any password/secured changes take effect immediately.
+		_apiSecuredCache = -1;
 
 		/* ConfigDB importFomStream */
 		String oldIP, oldSSID, oldDeviceName, oldCurrentPinConfigName, oldSyslogHost;
@@ -1047,7 +1132,11 @@ void ApplicationWebserver::onInfo(HttpRequest& request, HttpResponse& response){
 			data[F("git_version")] = fw_git_version;
 			data[F("build_type")] = BUILD_TYPE;
 			data[F("git_date")] = fw_git_date;
-			data[F("webapp_version")] = WEBAPP_VERSION;
+			{
+				AppConfig::Root::Webapp webappCfg(*app.cfg);
+				String installedVer = webappCfg.getInstalledVersion();
+				data[F("webapp_version")] = installedVer.length() > 0 ? installedVer : String(WEBAPP_VERSION);
+			}
 			data[F("sming")] = SMING_VERSION;
 			data[F("event_num_clients")] = app.eventserver.activeClients;
 			data[F("uptime")] = app.getUptime();

--- a/include/application.h
+++ b/include/application.h
@@ -22,6 +22,7 @@
 #pragma once
 #include <RGBWWCtrl.h>
 #include <otaupdate.h>
+#include <webappota.h>
 #include <controllers.h>
 #include <mdnsHandler.h>
 #ifndef SMING_RELEASE
@@ -109,6 +110,7 @@ public:
     std::unique_ptr<Controllers> controllers;
     
     ApplicationOTA ota;
+    WebappOta webappOta;
     std::unique_ptr<AppConfig> cfg;
     std::unique_ptr<AppData> data;
 

--- a/include/fileList.h
+++ b/include/fileList.h
@@ -1,0 +1,4 @@
+#define FILE_LIST(XX) \
+        XX(pinconfig_json, "config/pinconfig.json") \
+        XX(captive_html, "captive.html") \
+        XX(updating_html, "updating.html")

--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -68,6 +68,8 @@ private:
     bool _reconnectPending = false;
     SimpleTimer _reconnectGateTimer;
     static void reconnectGateTimeoutCb(void* arg);
+    Timer _reconnectTimer;
+    void doReconnect();
 
     bool _isRunning = false;
     MqttClient* mqtt = nullptr;

--- a/include/webappota.h
+++ b/include/webappota.h
@@ -1,0 +1,126 @@
+/**
+ * @file
+ * @author  Peter Jakobs http://github.com/pljakobs
+ *
+ * @section LICENSE
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details at
+ * https://www.gnu.org/copyleft/gpl.html
+ *
+ * @section DESCRIPTION
+ *
+ * WebappOta — background webapp file-fetch and LittleFS staging/activation.
+ *
+ * Flow:
+ *   checkForUpdate()
+ *     → queryApi()               (HTTP GET /api/webapp/latest?branch=…&firmware_version=…)
+ *     → onApiResponse()          (parse JSON; compare versions; populate _files)
+ *     → startNextDownload()      (per file: makedirs, HttpClient::downloadFile)
+ *     → onFileDownloaded()       (verify MD5; advance index or activate)
+ *     → activateStaging()        (move files from staging/ to root, update ConfigDB)
+ *
+ * File layout on LittleFS:
+ *   staging/<path>  — downloaded, verified files awaiting activation
+ *   <path>          — active webapp files served by the webserver
+ *
+ * ConfigDB state (AppConfig::Root::Webapp):
+ *   enabled            — master switch; checkForUpdate() is a no-op when false
+ *   api_base_url       — e.g. "https://lightinator.de/api"
+ *   installed_version  — persisted after successful activation
+ *   installed_md5      — persisted after successful activation (last file md5)
+ *   last_check_status  — "ok" | "no_update" | "api_error" | "download_error" | "md5_error"
+ */
+#pragma once
+
+#include <Network/Http/HttpClient.h>
+#include <Timer.h>
+#include <ArduinoJson.h>
+#include <vector>
+
+class WebappOta
+{
+public:
+    /**
+     * @brief Trigger a check for a newer webapp from the version API.
+     *
+     * Call this once after the WiFi station has obtained an IP address.
+     * Re-entrant: a second call while a check/download is in progress is
+     * silently ignored.
+     */
+    void checkForUpdate();
+
+    bool isActive() const
+    {
+        return _state != State::IDLE;
+    }
+
+    // Returns true if a previous download was interrupted and not yet completed.
+    // Persisted in ConfigDB; survives reboots. Checked by checkForUpdate() on boot.
+    bool wasInterrupted() const;
+
+    /**
+     * @brief Fill @p obj with current OTA state for the /webapp_status endpoint.
+     *
+     * Keys: state (string), file (int, 1-based current), total (int),
+     *       file_path (string), version (string), last_status (string from ConfigDB).
+     */
+    void fillStatusJson(JsonObject& obj) const;
+
+    // Broadcast current state as a 'webapp_ota_status' WebSocket message.
+    // Called at each state transition so the updating.html page can react
+    // without polling /webapp_status over HTTP.
+    void broadcastStatus() const;
+
+private:
+    enum class State {
+        IDLE,
+        QUERYING_API,
+        DOWNLOADING,
+        ACTIVATING,
+    };
+
+    struct FileEntry {
+        String path;        ///< relative path, e.g. "assets/index.js.gz"
+        String expectedMd5; ///< lowercase hex MD5 from API response
+        String url;         ///< absolute download URL
+    };
+
+    // --- API query ---
+    void queryApi(const String& branch, const String& firmwareVersion, const String& apiBaseUrl);
+    int onApiResponse(HttpConnection& client, bool successful);
+
+    // --- File download ---
+    void startNextDownload();
+    int onFileDownloaded(HttpConnection& client, bool successful);
+    void verifyAndContinue();
+    void activateStagingDeferred();
+
+    // --- Activation ---
+    bool activateStaging();
+    static bool moveTree(const String& srcDir, const String& dstDir);
+
+    // --- Helpers ---
+    bool verifyFileMd5(const String& filePath, const String& expectedMd5);
+    void saveState(const String& version, const String& md5, const String& status);
+    void cleanupStaging();
+    static String extractBranch(const String& firmwareVersion);
+    static String stagingPath(const String& relPath);
+    static bool ensureParentDir(const String& path);
+
+    // --- State ---
+    State _state{State::IDLE};
+    String _pendingVersion;
+    std::vector<FileEntry> _files;
+    unsigned _fileIndex{0};
+    unsigned _totalFiles{0};  ///< total files in this version (including already-verified ones)
+    HttpClient _httpClient;
+    Timer _retryTimer; ///< backoff timer for failed checks
+};

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -61,7 +61,14 @@ private:
 
     bool _init = false;
     bool _running = false;
-    
+
+    // Cached security flag: -1=not yet read, 0=unsecured, 1=secured
+    int _apiSecuredCache = -1;
+
+    // Rate-limiting for /webapp_status: cached serialised JSON + timestamp
+    String _webappStatusCache;
+    unsigned long _webappStatusCacheTime = 0;
+    static constexpr unsigned long WEBAPP_STATUS_CACHE_MS = 3000;
 
     WebsocketResource* wsResource = nullptr;
     WebsocketList webSockets;
@@ -72,6 +79,7 @@ private:
     void onFile(HttpRequest &request, HttpResponse &response);
     void onIndex(HttpRequest &request, HttpResponse &response);
     void onWebapp(HttpRequest &request, HttpResponse &response);
+    void onWebappStatus(HttpRequest &request, HttpResponse &response);
     void onConfig(HttpRequest &request, HttpResponse &response);
     void onInfo(HttpRequest &request, HttpResponse &response);
     void onColor(HttpRequest &request, HttpResponse &response);

--- a/manage_version.py
+++ b/manage_version.py
@@ -469,6 +469,60 @@ def cull_history(data, dry_run=False):
     
     return data
 
+def add_or_update_webapp_entry(data, branch, version, base_url, files=None, comment=''):
+    """Add or update a webapp entry in version.json."""
+    if "webapp" not in data:
+        data["webapp"] = []
+    if "webapp_history" not in data:
+        data["webapp_history"] = []
+    files = files or []
+    branch = branch.strip().lower()
+    comment = comment or ''
+
+    for i, entry in enumerate(data["webapp"]):
+        if entry["branch"].strip().lower() == branch:
+            if entry["version"] == version:
+                data["webapp"][i] = {
+                    "branch": entry["branch"],
+                    "version": version,
+                    "url": base_url,
+                    "files": files,
+                    "comment": comment if comment else entry.get("comment", "")
+                }
+                print(f"Updated webapp entry for {branch} version {version} (same version, URL/files updated)")
+            else:
+                print(f"Moving webapp {branch}: {entry['version']} to history")
+                data["webapp_history"].append(dict(entry))
+                data["webapp"][i] = {
+                    "branch": branch,
+                    "version": version,
+                    "url": base_url,
+                    "files": files,
+                    "comment": comment
+                }
+                print(f"Added new webapp entry for {branch} version {version}")
+            return data
+
+    data["webapp"].append({
+        "branch": branch,
+        "version": version,
+        "url": base_url,
+        "files": files,
+        "comment": comment
+    })
+    print(f"Added new webapp entry for {branch} version {version}")
+    return data
+
+
+def list_webapp_entries(data, branch=None):
+    """List webapp entries, optionally filtered by branch."""
+    entries = data.get("webapp", [])
+    if branch:
+        branch = branch.strip().lower()
+        entries = [e for e in entries if e["branch"].strip().lower() == branch]
+    return entries
+
+
 def main():
     if len(sys.argv) < 3:
         print("Usage: script.py <json_file_or_url> [add|delete|list|cull] [arguments]")
@@ -571,7 +625,49 @@ def main():
             print(f"{history_marker}{entry['soc']}/{entry['type']}/{entry['branch']}: {entry['fw_version']}{url_status} - {entry['files']['rom']['url']}")
         return
 
-    print("Invalid action. Use add, delete, list, or cull.")
+    if action == 'add-webapp':
+        if len(sys.argv) < 6:
+            print("Usage: script.py <json_file> add-webapp <branch> <version> <base_url> [--files-json-b64 <base64>] [--comment-b64 <base64>]")
+            return
+        branch = sys.argv[3]
+        version = sys.argv[4]
+        base_url = sys.argv[5]
+        files = []
+        comment = ''
+        args = sys.argv[6:]
+        idx = 0
+        while idx < len(args):
+            if args[idx] == '--files-json-b64' and idx + 1 < len(args):
+                try:
+                    files = json.loads(base64.b64decode(args[idx + 1]).decode('utf-8'))
+                except Exception as exc:
+                    print(f"Error decoding --files-json-b64: {exc}")
+                    return
+                idx += 2
+            elif args[idx] == '--comment-b64' and idx + 1 < len(args):
+                try:
+                    comment = base64.b64decode(args[idx + 1]).decode('utf-8')
+                except Exception as exc:
+                    print(f"Error decoding --comment-b64: {exc}")
+                    return
+                idx += 2
+            else:
+                idx += 1
+        data = add_or_update_webapp_entry(data, branch, version, base_url, files, comment)
+        save_json(data, file_path_or_url)
+        print(f"Webapp entry added/updated for {branch} version {version}.")
+        return
+
+    if action == 'list-webapp':
+        branch = sys.argv[3] if len(sys.argv) > 3 else None
+        entries = list_webapp_entries(data, branch)
+        print(f"Found {len(entries)} webapp entries:")
+        for entry in sorted(entries, key=lambda e: e['branch']):
+            files_count = len(entry.get("files", []))
+            print(f"  {entry['branch']}: {entry['version']} ({files_count} files) - {entry['url']}")
+        return
+
+    print("Invalid action. Use add, delete, list, cull, add-webapp, or list-webapp.")
 
 if __name__ == "__main__":
     main()

--- a/manage_version.py
+++ b/manage_version.py
@@ -7,7 +7,7 @@ import base64
 import requests
 from urllib.parse import urlparse
 
-def update_latest_symlink(data, base_dir='download'):
+def update_latest_symlink(data, base_dir='download/firmware'):
     """
     For each branch (develop, testing, main), create or update a symlink (or copy) in download/latest-<branch>/app_merged.bin
     pointing to the latest single_image/app_merged.bin for that branch.
@@ -25,7 +25,12 @@ def update_latest_symlink(data, base_dir='download'):
         # Extract the local path to app_merged.bin
         parsed = urlparse(url)
         rel_path = parsed.path.lstrip('/')
-        src_path = os.path.join(base_dir, rel_path) if not rel_path.startswith(base_dir) else rel_path
+        if rel_path.startswith(base_dir.rstrip('/') + '/'):
+            src_path = rel_path
+        elif rel_path.startswith('download/'):
+            src_path = rel_path
+        else:
+            src_path = os.path.join(base_dir, rel_path)
         # Target symlink directory
         link_dir = os.path.join(base_dir, f'latest-{branch}')
         os.makedirs(link_dir, exist_ok=True)

--- a/manage_version.py
+++ b/manage_version.py
@@ -474,7 +474,7 @@ def cull_history(data, dry_run=False):
     
     return data
 
-def add_or_update_webapp_entry(data, branch, version, base_url, files=None, comment=''):
+def add_or_update_webapp_entry(data, branch, version, files=None, comment='', webapp_type='debug', min_firmware=''):
     """Add or update a webapp entry in version.json."""
     if "webapp" not in data:
         data["webapp"] = []
@@ -482,26 +482,33 @@ def add_or_update_webapp_entry(data, branch, version, base_url, files=None, comm
         data["webapp_history"] = []
     files = files or []
     branch = branch.strip().lower()
+    webapp_type = webapp_type.strip().lower() if webapp_type else 'debug'
+    if webapp_type not in ('debug', 'release'):
+        print(f"Invalid webapp type '{webapp_type}', defaulting to 'debug'")
+        webapp_type = 'debug'
+    min_firmware = min_firmware.strip()
     comment = comment or ''
 
     for i, entry in enumerate(data["webapp"]):
         if entry["branch"].strip().lower() == branch:
             if entry["version"] == version:
                 data["webapp"][i] = {
-                    "branch": entry["branch"],
                     "version": version,
-                    "url": base_url,
+                    "type": webapp_type,
+                    "branch": entry["branch"],
+                    "min_firmware": min_firmware,
                     "files": files,
                     "comment": comment if comment else entry.get("comment", "")
                 }
-                print(f"Updated webapp entry for {branch} version {version} (same version, URL/files updated)")
+                print(f"Updated webapp entry for {branch} version {version} (same version, metadata/files updated)")
             else:
                 print(f"Moving webapp {branch}: {entry['version']} to history")
                 data["webapp_history"].append(dict(entry))
                 data["webapp"][i] = {
-                    "branch": branch,
                     "version": version,
-                    "url": base_url,
+                    "type": webapp_type,
+                    "branch": branch,
+                    "min_firmware": min_firmware,
                     "files": files,
                     "comment": comment
                 }
@@ -509,9 +516,10 @@ def add_or_update_webapp_entry(data, branch, version, base_url, files=None, comm
             return data
 
     data["webapp"].append({
-        "branch": branch,
         "version": version,
-        "url": base_url,
+        "type": webapp_type,
+        "branch": branch,
+        "min_firmware": min_firmware,
         "files": files,
         "comment": comment
     })
@@ -631,15 +639,16 @@ def main():
         return
 
     if action == 'add-webapp':
-        if len(sys.argv) < 6:
-            print("Usage: script.py <json_file> add-webapp <branch> <version> <base_url> [--files-json-b64 <base64>] [--comment-b64 <base64>]")
+        if len(sys.argv) < 5:
+            print("Usage: script.py <json_file> add-webapp <branch> <version> [--files-json-b64 <base64>] [--comment-b64 <base64>] [--type <debug|release>] [--min-firmware <semver>]")
             return
         branch = sys.argv[3]
         version = sys.argv[4]
-        base_url = sys.argv[5]
         files = []
         comment = ''
-        args = sys.argv[6:]
+        webapp_type = 'debug'
+        min_firmware = ''
+        args = sys.argv[5:]
         idx = 0
         while idx < len(args):
             if args[idx] == '--files-json-b64' and idx + 1 < len(args):
@@ -656,9 +665,15 @@ def main():
                     print(f"Error decoding --comment-b64: {exc}")
                     return
                 idx += 2
+            elif args[idx] == '--type' and idx + 1 < len(args):
+                webapp_type = args[idx + 1]
+                idx += 2
+            elif args[idx] == '--min-firmware' and idx + 1 < len(args):
+                min_firmware = args[idx + 1]
+                idx += 2
             else:
                 idx += 1
-        data = add_or_update_webapp_entry(data, branch, version, base_url, files, comment)
+        data = add_or_update_webapp_entry(data, branch, version, files, comment, webapp_type, min_firmware)
         save_json(data, file_path_or_url)
         print(f"Webapp entry added/updated for {branch} version {version}.")
         return
@@ -669,7 +684,10 @@ def main():
         print(f"Found {len(entries)} webapp entries:")
         for entry in sorted(entries, key=lambda e: e['branch']):
             files_count = len(entry.get("files", []))
-            print(f"  {entry['branch']}: {entry['version']} ({files_count} files) - {entry['url']}")
+            entry_type = entry.get("type", "unknown")
+            min_fw = entry.get("min_firmware", "")
+            min_fw_text = f" min_firmware={min_fw}" if min_fw else ""
+            print(f"  {entry['branch']}: {entry['version']} type={entry_type}{min_fw_text} ({files_count} files)")
         return
 
     print("Invalid action. Use add, delete, list, cull, add-webapp, or list-webapp.")

--- a/webapp/captive.html
+++ b/webapp/captive.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Device Setup</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,sans-serif;background:#f0f2f5;color:#222;padding:12px}
+h1{font-size:1.2rem;margin-bottom:16px;color:#1976d2}
+.card{background:#fff;border-radius:8px;padding:16px;margin-bottom:12px;box-shadow:0 1px 4px rgba(0,0,0,.12)}
+label{display:block;font-size:.8rem;color:#555;margin-bottom:4px}
+input{width:100%;padding:9px 10px;border:1px solid #ccc;border-radius:6px;font-size:.95rem;outline:none}
+input:focus{border-color:#1976d2}
+.net-list{border:1px solid #e0e0e0;border-radius:6px;max-height:200px;overflow-y:auto;margin-bottom:10px}
+.net-item{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;cursor:pointer;border-bottom:1px solid #f0f0f0;font-size:.9rem}
+.net-item:last-child{border-bottom:none}
+.net-item:hover,.net-item.sel{background:#e3f0ff}
+.bars{display:flex;align-items:flex-end;gap:2px;height:16px}
+.bar{width:4px;background:#aaa;border-radius:1px}
+.bar.on{background:#1976d2}
+.enc{font-size:.7rem;color:#888;margin-left:6px}
+.row{display:flex;gap:8px;align-items:center}
+.row label{margin:0;white-space:nowrap}
+button{padding:10px 20px;border:none;border-radius:6px;background:#1976d2;color:#fff;font-size:.95rem;cursor:pointer;width:100%}
+button:hover{background:#1565c0}
+button:disabled{background:#90b8e0;cursor:not-allowed}
+.scan-btn{background:none;border:1px solid #1976d2;color:#1976d2;padding:6px 12px;font-size:.8rem;width:auto;border-radius:6px;cursor:pointer}
+.scan-btn:hover{background:#e3f0ff}
+.msg{margin-top:10px;padding:10px;border-radius:6px;font-size:.85rem;text-align:center}
+.msg.info{background:#e3f0ff;color:#1565c0}
+.msg.ok{background:#e8f5e9;color:#2e7d32}
+.msg.err{background:#ffebee;color:#c62828}
+.spinner{display:inline-block;width:14px;height:14px;border:2px solid #90caf9;border-top-color:#1976d2;border-radius:50%;animation:spin .8s linear infinite;vertical-align:middle;margin-right:6px}
+@keyframes spin{to{transform:rotate(360deg)}}
+#done{display:none}
+a{color:#1976d2}
+</style>
+</head>
+<body>
+<h1>&#x1F4F6; Device Setup</h1>
+
+<div class="card">
+  <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">
+    <strong>WiFi Networks</strong>
+    <button class="scan-btn" id="scanBtn" onclick="doScan()">&#x21BB; Scan</button>
+  </div>
+  <div id="netList" class="net-list"><div style="padding:12px;color:#888;font-size:.85rem">Scanning&hellip;</div></div>
+</div>
+
+<div class="card">
+  <div style="margin-bottom:10px">
+    <label for="hn">Hostname (optional)</label>
+    <input id="hn" type="text" placeholder="e.g. rgbww-living" autocomplete="off" spellcheck="false">
+  </div>
+  <div style="margin-bottom:10px">
+    <label for="ss">Network (SSID)</label>
+    <input id="ss" type="text" placeholder="Select above or type" autocomplete="off" spellcheck="false">
+  </div>
+  <div style="margin-bottom:16px">
+    <label for="pw">Password</label>
+    <div class="row" style="gap:6px">
+      <input id="pw" type="password" autocomplete="off">
+      <button onclick="togglePwd()" style="width:auto;padding:9px 12px;background:#eee;color:#333;border:1px solid #ccc;font-size:.8rem" id="eyeBtn">Show</button>
+    </div>
+  </div>
+  <button id="connectBtn" onclick="doConnect()" disabled>Connect</button>
+</div>
+
+<div id="msg" class="msg" style="display:none"></div>
+
+<div class="card" id="done">
+  <strong>&#x2705; Connected!</strong>
+  <div style="margin-top:10px;font-size:.9rem" id="connInfo"></div>
+</div>
+
+<script>
+var nets=[],selSsid='',scanning=false,ws=null;
+
+function bars(rssi,enc){
+  var lvl=rssi>=-50?4:rssi>=-65?3:rssi>=-75?2:rssi>=-90?1:0;
+  var locked=enc&&enc!=='Open'?'&#x1F512;':'';
+  var b='<div class="bars">';
+  for(var i=1;i<=4;i++) b+='<div class="bar'+(i<=lvl?' on':'')+'" style="height:'+(i*4)+'px"></div>';
+  b+='</div>'+locked;
+  return b;
+}
+
+function renderNets(){
+  var el=document.getElementById('netList');
+  if(!nets.length){el.innerHTML='<div style="padding:12px;color:#888;font-size:.85rem">No networks found</div>';return;}
+  var h='';
+  for(var i=0;i<nets.length;i++){
+    var n=nets[i];
+    var sel=n.ssid===selSsid?' sel':'';
+    h+='<div class="net-item'+sel+'" onclick="pickNet(\''+n.ssid.replace(/'/g,"\\'")+'\')">'
+      +'<span>'+esc(n.ssid)+'<span class="enc">'+n.encryption+'</span></span>'
+      +'<span style="display:flex;align-items:center">'+bars(n.signal,n.encryption)+'</span>'
+      +'</div>';
+  }
+  el.innerHTML=h;
+  document.getElementById('connectBtn').disabled=!document.getElementById('ss').value.trim();
+}
+
+function esc(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
+
+function pickNet(ssid){selSsid=ssid;document.getElementById('ss').value=ssid;renderNets();document.getElementById('connectBtn').disabled=false;}
+
+document.getElementById('ss').addEventListener('input',function(){document.getElementById('connectBtn').disabled=!this.value.trim();});
+
+function togglePwd(){
+  var i=document.getElementById('pw');
+  var show=i.type==='password';
+  i.type=show?'text':'password';
+  document.getElementById('eyeBtn').textContent=show?'Hide':'Show';
+}
+
+function showMsg(txt,cls){var el=document.getElementById('msg');el.className='msg '+cls;el.innerHTML=txt;el.style.display='block';}
+function hideMsg(){document.getElementById('msg').style.display='none';}
+
+function fetchNets(){
+  fetch('/networks').then(function(r){return r.json();}).then(function(d){
+    if(d.scanning){scanning=true;setTimeout(fetchNets,1500);return;}
+    scanning=false;
+    document.getElementById('scanBtn').disabled=false;
+    if(d.available&&d.available.length){
+      nets=d.available.sort(function(a,b){return b.signal-a.signal;});
+    }
+    renderNets();
+  }).catch(function(){setTimeout(fetchNets,2000);});
+}
+
+function doScan(){
+  document.getElementById('scanBtn').disabled=true;
+  document.getElementById('netList').innerHTML='<div style="padding:12px;color:#888;font-size:.85rem"><span class="spinner"></span>Scanning&hellip;</div>';
+  nets=[];scanning=true;
+  fetch('/scan_networks',{method:'POST'}).then(function(){setTimeout(fetchNets,1000);}).catch(function(){setTimeout(fetchNets,1000);});
+}
+
+function openWs(){
+  var proto=location.protocol==='https:'?'wss':'ws';
+  ws=new WebSocket(proto+'://'+location.host+'/ws');
+  ws.onmessage=function(ev){
+    try{
+      var m=JSON.parse(ev.data);
+      if(m.method==='wifi_status'&&m.params&&m.params.station&&m.params.station.connected){
+        onConnected(m.params.station);
+      } else if(m.method==='wifi_status'&&m.params&&m.params.message){
+        showMsg('<span class="spinner"></span>'+esc(m.params.message),'info');
+      }
+    }catch(e){}
+  };
+  ws.onerror=function(){ws=null;};
+}
+
+function onConnected(sta){
+  document.getElementById('connectBtn').disabled=false;
+  document.getElementById('done').style.display='block';
+  var ip=sta.ip||'';
+  document.getElementById('connInfo').innerHTML=
+    'SSID: <b>'+esc(sta.ssid||'')+'</b><br>'
+    +'IP: <a href="http://'+ip+'">'+ip+'</a><br>'
+    +'Gateway: '+esc(sta.gateway||'');
+  showMsg('&#x2705; Connected! <a href="http://'+ip+'">Open device at '+ip+'</a>','ok');
+  // start countdown
+  var n=10;
+  var t=setInterval(function(){
+    n--;
+    if(n<=0){clearInterval(t);location.href='http://'+ip;}
+  },1000);
+}
+
+var pollTimer=null;
+function startPoll(){
+  clearInterval(pollTimer);
+  var tries=0;
+  pollTimer=setInterval(function(){
+    tries++;
+    fetch('/connect').then(function(r){return r.json();}).then(function(d){
+      if(d.status===3){clearInterval(pollTimer);onConnected({ssid:d.ssid,ip:d.ip,gateway:d.gateway||''});}
+      else if(d.status===4){clearInterval(pollTimer);showMsg('&#x274C; '+esc(d.error||'Connection failed'),'err');document.getElementById('connectBtn').disabled=false;}
+    }).catch(function(){});
+    if(tries>=30){clearInterval(pollTimer);showMsg('&#x274C; Timed out. Please try again.','err');document.getElementById('connectBtn').disabled=false;}
+  },1000);
+}
+
+async function doConnect(){
+  var ssid=document.getElementById('ss').value.trim();
+  var pw=document.getElementById('pw').value;
+  var hn=document.getElementById('hn').value.trim();
+  if(!ssid) return;
+  document.getElementById('connectBtn').disabled=true;
+  showMsg('<span class="spinner"></span>Connecting&hellip;','info');
+  try{
+    if(hn){
+      await fetch('/config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({general:{device_name:hn}})}).catch(function(){});
+    }
+    var r=await fetch('/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:ssid,password:pw})});
+    if(!r.ok){showMsg('&#x274C; Request failed','err');document.getElementById('connectBtn').disabled=false;return;}
+    openWs();
+    startPoll();
+  }catch(e){
+    showMsg('&#x274C; '+esc(e.message),'err');
+    document.getElementById('connectBtn').disabled=false;
+  }
+}
+
+window.onload=function(){doScan();};
+</script>
+</body>
+</html>

--- a/webapp/updating.html
+++ b/webapp/updating.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Downloading Webapp&hellip;</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,sans-serif;background:#f0f2f5;color:#222;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:16px}
+.card{background:#fff;border-radius:10px;padding:28px 24px;max-width:380px;width:100%;box-shadow:0 2px 8px rgba(0,0,0,.14);text-align:center}
+h1{font-size:1.1rem;margin-bottom:6px;color:#1976d2}
+.sub{font-size:.85rem;color:#666;margin-bottom:24px}
+.spinner{display:inline-block;width:48px;height:48px;border:4px solid #bbdefb;border-top-color:#1976d2;border-radius:50%;animation:spin 1s linear infinite;margin-bottom:20px}
+@keyframes spin{to{transform:rotate(360deg)}}
+.state{font-size:.95rem;font-weight:600;margin-bottom:8px}
+.detail{font-size:.8rem;color:#555;margin-bottom:16px;word-break:break-all}
+.progress-wrap{background:#e3f0ff;border-radius:4px;height:8px;width:100%;margin-bottom:16px;overflow:hidden}
+.progress-bar{height:8px;background:#1976d2;border-radius:4px;transition:width .4s}
+.ok{color:#2e7d32}
+.err{color:#c62828}
+.ws-indicator{display:inline-flex;align-items:center;gap:5px;font-size:.72rem;color:#888;margin-bottom:18px}
+.ws-dot{width:8px;height:8px;border-radius:50%;background:#bbb;flex-shrink:0}
+.ws-dot.connected{background:#43a047}
+.ws-dot.polling{background:#fb8c00}
+.ws-dot.connecting{background:#90caf9;animation:pulse .8s ease-in-out infinite alternate}
+@keyframes pulse{to{opacity:.3}}
+button{padding:9px 20px;border:none;border-radius:6px;background:#1976d2;color:#fff;font-size:.9rem;cursor:pointer;margin-top:8px}
+button:hover{background:#1565c0}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="spinner" id="spinner"></div>
+  <h1 id="title">Downloading webapp&hellip;</h1>
+  <div class="sub" id="sub">Please wait while the device fetches its interface files.</div>
+  <div class="state" id="stateLabel"></div>
+  <div class="progress-wrap" id="progWrap" style="display:none">
+    <div class="progress-bar" id="progBar" style="width:0%"></div>
+  </div>
+  <div class="detail" id="detail"></div>
+  <div class="ws-indicator"><span class="ws-dot connecting" id="wsDot"></span><span id="wsLabel">Connecting…</span></div>
+  <button id="retryBtn" style="display:none" onclick="location.reload()">Retry</button>
+</div>
+<script>
+var stateLabels={
+  idle:'Idle',
+  querying_api:'Checking for updates\u2026',
+  downloading:'Downloading files\u2026',
+  activating:'Activating webapp\u2026'
+};
+
+var done=false;
+
+function setWsIndicator(state){
+  var dot=document.getElementById('wsDot');
+  var lbl=document.getElementById('wsLabel');
+  dot.className='ws-dot '+state;
+  var labels={connected:'WebSocket ✓',polling:'HTTP polling',connecting:'Connecting…'};
+  lbl.textContent=labels[state]||state;
+}
+
+function applyStatus(d){
+  if(done) return;
+  var state=d.state||'idle';
+  var lbl=stateLabels[state]||state;
+  document.getElementById('stateLabel').innerHTML=lbl;
+
+  if(state==='downloading'&&d.total>0){
+    var pct=Math.round((d.file/d.total)*100);
+    document.getElementById('progWrap').style.display='block';
+    document.getElementById('progBar').style.width=pct+'%';
+    document.getElementById('detail').textContent='File '+d.file+' / '+d.total+(d.file_path?' \u2014 '+d.file_path:'');
+  } else if(state==='querying_api'||state==='activating'){
+    document.getElementById('progWrap').style.display='none';
+    document.getElementById('detail').textContent='';
+  }
+
+  if(state==='idle'){
+    if(d.last_status==='ok'||d.last_status==='no_update'){
+      done=true;
+      document.getElementById('spinner').style.display='none';
+      document.getElementById('title').innerHTML='<span class="ok">&#x2705; Ready!</span>';
+      document.getElementById('sub').textContent='Loading interface\u2026';
+      setTimeout(function(){location.replace('/');},1200);
+      return;
+    } else if(d.last_status){
+      done=true;
+      document.getElementById('spinner').style.display='none';
+      document.getElementById('title').innerHTML='<span class="err">&#x274C; Update failed</span>';
+      document.getElementById('sub').textContent='Could not download webapp files.';
+      document.getElementById('detail').textContent='Status: '+d.last_status;
+      document.getElementById('retryBtn').style.display='inline-block';
+      return;
+    }
+  }
+}
+
+// ── WebSocket path ────────────────────────────────────────────────────────────
+var ws=null;
+var wsOk=false;
+var fallbackTimer=null;
+var wsRetryTimer=null;
+
+function startFallbackPoll(){
+  setWsIndicator('polling');
+  if(fallbackTimer) return;
+  // Poll at 12 s — just above the server's 10 s keepAlive window — so the
+  // previous TCP connection fully ages out before we open a new one.
+  // This prevents connections stacking up and pressuring heap during download.
+  fallbackTimer=setTimeout(function poll(){
+    if(done||wsOk) return;
+    fetch('/webapp_status').then(function(r){return r.json();}).then(function(d){
+      applyStatus(d);
+      if(!done) fallbackTimer=setTimeout(poll,20000);
+    }).catch(function(){
+      if(!done) fallbackTimer=setTimeout(poll,20000);
+    });
+  },0);
+}
+
+function connectWs(){
+  if(done) return;
+  var proto=location.protocol==='https:'?'wss':'ws';
+  try{
+    ws=new WebSocket(proto+'://'+location.host+'/ws');
+  } catch(e){ startFallbackPoll(); return; }
+
+  // Device may be busy downloading — give it 10 s to accept the upgrade.
+  var wsTimeout=setTimeout(function(){
+    if(!wsOk){
+      startFallbackPoll();
+      // Keep retrying the WS every 15 s so we switch off polling once it connects.
+      wsRetryTimer=setInterval(function(){
+        if(done||wsOk){ clearInterval(wsRetryTimer); return; }
+        connectWs();
+      },15000);
+    }
+  },10000);
+
+  ws.onopen=function(){
+    clearTimeout(wsTimeout);
+    wsOk=true;
+    clearInterval(wsRetryTimer);
+    setWsIndicator('connected');
+    // Stop HTTP fallback polling now that WS is live.
+    if(fallbackTimer){ clearTimeout(fallbackTimer); fallbackTimer=null; }
+  };
+
+  ws.onmessage=function(ev){
+    try{
+      var msg=JSON.parse(ev.data);
+      if(msg.method==='webapp_ota_status'&&msg.params){
+        applyStatus(msg.params);
+      }
+    } catch(e){}
+  };
+
+  ws.onerror=function(){
+    if(!wsOk) startFallbackPoll();
+  };
+
+  ws.onclose=function(){
+    if(!done&&wsOk){
+      // WS dropped mid-update (device rebooted after activation) — fall back to
+      // polling so we catch the final idle/ok state after the device comes back.
+      wsOk=false;
+      startFallbackPoll();
+    }
+  };
+}
+
+window.onload=function(){
+  setWsIndicator('connecting');
+  if(typeof WebSocket!=='undefined'){
+    connectWs();
+  } else {
+    startFallbackPoll();
+  }
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR introduces a complete background webapp OTA delivery system. After the first boot the firmware serves only a minimal bootstrap set embedded in flash (captive portal, updating page, pin config). The full webapp is then fetched from the lightinator.de version API, staged in LittleFS, MD5-verified, and atomically activated — without any partition-level reflash.

---

## Commits

### `feat(webappota)`: implement background webapp OTA with LittleFS staging

**Config schema** (`app-config.cfgdb`): new `webapp` object persisted via ConfigDB:
- `enabled`, `api_base_url`, `installed_version`, `installed_md5`, `last_check_status`, `in_progress`

**Application** (`include/application.h`): adds `WebappOta webappOta` member.

**Networking** (`app/networking.cpp`):
- Triggers `webappOta.checkForUpdate()` on STA Got-IP.
- Defers AP shutdown while a download is in progress (browser may be watching the updating page via the AP).

**Webserver** (`app/webserver.cpp`, `include/webserver.h`):
- `onIndex()` replaced with a three-way decision: captive portal → updating page → redirect to LFS index.html.
- Both `captive.html` and `updating.html` served with `Cache-Control: no-store`.
- New `/webapp_status` endpoint: returns OTA progress JSON, 2 s cache while active, bypassed when idle.
- `wsConnected()` pushes current OTA state immediately to newly connected WebSocket clients.
- `onFile()`: heap guard raised to 10 KB; `sendFile(name, true)` for correct MIME type on `.gz` files.
- `checkHeap()` `Retry-After`: 30 s during OTA, 4 s otherwise.
- `_apiSecuredCache`: avoid re-opening ConfigDB on every auth check.

**API** (`app/apihandler.cpp`):
- `keep_alive` no-op handler (prevents WebSocket disconnect on ping).
- `webapp_version` in all info responses now reads `getInstalledVersion()` at runtime, falling back to compile-time `WEBAPP_VERSION`.

---

### `fix(telemetry)`: defer MQTT reconnect via timer to prevent use-after-free

`reconnect()` was calling `stop()` then `delay(1000)` inline. TCP callbacks could fire against the deleted `MqttClient` during the yield. Fixed with a 1 s one-shot timer that calls `doReconnect()` from the event loop.

---

### `refactor(application)`: move debugStream definition before Application

Avoids a potential static-initialisation-order issue on some toolchain/optimisation combinations.

---

### `fix(otaupdate)`: annotate known partition-table validation bugs with TODOs

Three pre-existing issues tagged #136 (inverted overlap condition), #137 (no flash upper-bound check), #138 (strncpy without null-termination guarantee). No functional change.

---

### `feat(manage_version)`: add type/min_firmware to webapp entries, drop base_url

`add-webapp` sub-command: removes unused `base_url` positional arg; adds `--type <debug|release>` and `--min-firmware <semver>`. Consistent JSON field order.

---

### `ci`: experimental branch uses minimal embedded file set, no full webapp zip extract

For **experimental** builds:
- `fileList.h` download skipped — the repo copy already has the 3-entry minimal list.
- Only 4 files extracted from `spa-files.zip`: `captive.html`, `updating.html`, `config/pinconfig.json`, `VERSION`.

For all other branches: unchanged full download + extract.